### PR TITLE
Fix cross-platform prediction artifact loading

### DIFF
--- a/libs/modeling/portable_artifacts.py
+++ b/libs/modeling/portable_artifacts.py
@@ -1,0 +1,64 @@
+"""Compatibility helpers for model artifacts serialized on another OS."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+from contextlib import contextmanager
+from typing import Iterator
+
+
+def _pathlib_pickle_mapping() -> tuple[str, type[pathlib.Path]] | None:
+    """Return the concrete pathlib class that should be remapped while unpickling."""
+    if os.name == "nt":
+        return "PosixPath", pathlib.WindowsPath
+    return "WindowsPath", pathlib.PosixPath
+
+
+def install_pathlib_pickle_compatibility() -> str | None:
+    """
+    Make pathlib pickles from the opposite OS load in this process.
+
+    AutoGluon lazily unpickles child model artifacts during prediction, so a
+    process-level compatibility install is more reliable than only wrapping the
+    initial predictor load.
+    """
+    mapping = _pathlib_pickle_mapping()
+    if mapping is None:
+        return None
+
+    source_name, replacement = mapping
+    if getattr(pathlib, source_name) is not replacement:
+        setattr(pathlib, source_name, replacement)
+    return source_name
+
+
+@contextmanager
+def pathlib_pickle_compatibility() -> Iterator[None]:
+    """Temporarily remap concrete pathlib classes while loading pickle artifacts."""
+    mapping = _pathlib_pickle_mapping()
+    if mapping is None:
+        yield
+        return
+
+    source_name, replacement = mapping
+    original = getattr(pathlib, source_name)
+    setattr(pathlib, source_name, replacement)
+    try:
+        yield
+    finally:
+        setattr(pathlib, source_name, original)
+
+
+def load_tabular_predictor(predictor_cls, path, **kwargs):
+    """Load an AutoGluon TabularPredictor with cross-OS pathlib pickle support."""
+    with pathlib_pickle_compatibility():
+        return predictor_cls.load(path, **kwargs)
+
+
+def load_joblib_artifact(path):
+    """Load a joblib artifact with cross-OS pathlib pickle support."""
+    import joblib
+
+    with pathlib_pickle_compatibility():
+        return joblib.load(path)

--- a/libs/modeling/train.py
+++ b/libs/modeling/train.py
@@ -23,6 +23,7 @@ from libs.feature_store.features import vSeven_testing2, vSeven_testing2_with_f1
 from libs.modeling.data_preparation import DataPreparation
 from libs.modeling.data_utils import balance_dataset, _swap_fighter_roles, filter_fights, load_training_data
 from libs.modeling.model_utils import ModelUtils
+from libs.modeling.portable_artifacts import load_joblib_artifact, load_tabular_predictor
 from libs.paths import data_file
 
 
@@ -245,9 +246,8 @@ class EnsemblePredictor:
         if scaler_path is None or not os.path.exists(scaler_path):
             return data.copy()
         
-        import joblib
         try:
-            scaler = joblib.load(scaler_path)
+            scaler = load_joblib_artifact(scaler_path)
             
             # Identify columns to exclude from scaling
             date_cols = ['event_date', 'fight_id', 'fighter_name', 'opp_name']
@@ -487,7 +487,8 @@ class EnsemblePredictor:
         # Walk-forward format: load windows + final_model
         window_dirs.sort(key=lambda x: x[0])
         for window_num, window_path in window_dirs:
-            predictor = TabularPredictor.load(
+            predictor = load_tabular_predictor(
+                TabularPredictor,
                 window_path,
                 require_version_match=False,
                 require_py_version_match=False,
@@ -498,7 +499,8 @@ class EnsemblePredictor:
             scaler_paths.append(scaler_path if os.path.exists(scaler_path) else None)
         
         if final_model_dir:
-            predictor = TabularPredictor.load(
+            predictor = load_tabular_predictor(
+                TabularPredictor,
                 final_model_dir,
                 require_version_match=False,
                 require_py_version_match=False,

--- a/predict.py
+++ b/predict.py
@@ -2,7 +2,6 @@ from libs.upcoming_fights import UpcomingFights
 import pandas as pd
 from libs.feature_store.create_inference_data import CreateInferenceData  # Keep for backward compatibility
 from libs.feature_store.inference import InferenceDataBuilder, filter_features_for_model
-import joblib
 from libs.visualization import FightVisualizer
 from libs.shap_visualization import ShapVisualizer
 from itertools import combinations
@@ -19,6 +18,12 @@ import urllib3
 import warnings
 from libs.bfo_scraper import BFOScraper
 from libs.modeling.discovery import is_loadable_prediction_model_dir
+from libs.modeling.portable_artifacts import (
+    install_pathlib_pickle_compatibility,
+    load_joblib_artifact,
+    load_tabular_predictor,
+    pathlib_pickle_compatibility,
+)
 from libs.paths import data_file, models_dir, picks_dir
 
 # Disable SSL warnings
@@ -967,7 +972,6 @@ def load_model_and_calibrator(model_path, use_calibrated=True):
     :return: Tuple of (predictor, calibrator or None)
     """
     from autogluon.tabular import TabularPredictor
-    import joblib
     import os
     
     ensemble_info_path = os.path.join(model_path, 'ensemble_info.txt')
@@ -989,7 +993,8 @@ def load_model_and_calibrator(model_path, use_calibrated=True):
     else:
         # Old single-model format
         print(f"Detected SINGLE model at {model_path}")
-        predictor = TabularPredictor.load(
+        predictor = load_tabular_predictor(
+            TabularPredictor,
             model_path,
             require_version_match=False,
             require_py_version_match=False,
@@ -1001,7 +1006,7 @@ def load_model_and_calibrator(model_path, use_calibrated=True):
         calibrator_path = os.path.join(model_path, 'calibrator.pkl')
         if os.path.exists(calibrator_path):
             try:
-                calibrator = joblib.load(calibrator_path)
+                calibrator = load_joblib_artifact(calibrator_path)
                 print(f"[ok] Loaded calibrator from {calibrator_path}")
             except Exception as e:
                 print(f"Warning: Could not load calibrator from {calibrator_path}: {e}")
@@ -1032,12 +1037,14 @@ def get_predictions(model, calibrator, scaled_X_df, use_calibrated=None):
     
     # Get original predictions - handle models trained with sample_weight
     try:
-        y_pred_proba = model.predict_proba(scaled_X_df)
+        with pathlib_pickle_compatibility():
+            y_pred_proba = model.predict_proba(scaled_X_df)
     except KeyError as e:
         if 'sample_weight' in str(e):
             scaled_X_df_with_weights = scaled_X_df.copy()
             scaled_X_df_with_weights['sample_weight'] = 1.0
-            y_pred_proba = model.predict_proba(scaled_X_df_with_weights)
+            with pathlib_pickle_compatibility():
+                y_pred_proba = model.predict_proba(scaled_X_df_with_weights)
             print(f"Added sample_weight column for prediction (model was trained with recency weights)")
         else:
             raise e
@@ -1086,7 +1093,7 @@ def get_predictions(model, calibrator, scaled_X_df, use_calibrated=None):
 def load_model(model_name):
     """Load an AutoGluon model from the specified path (deprecated - use load_model_and_calibrator)"""
     from autogluon.tabular import TabularPredictor
-    predictor = TabularPredictor.load(model_name)
+    predictor = load_tabular_predictor(TabularPredictor, model_name)
     return predictor
 
 def create_conf_parlays(results):
@@ -1247,6 +1254,23 @@ def has_positive_ev(ai_odds_str, bookie_odds_str):
     return ev > 0
 
 
+def maybe_take_screenshots(output_dir, enabled=False):
+    """Optionally create PNG screenshots without failing an otherwise successful prediction."""
+    if not enabled:
+        print("Skipping screenshots. Use --screenshots to create PNG captures from generated HTML visualizations.")
+        return False
+
+    print("\nTaking screenshots of visualizations...")
+    try:
+        take_screenshots(output_dir)
+    except Exception as exc:
+        print(f"Warning: Screenshot generation failed: {exc}. Prediction artifacts were still written.")
+        return False
+
+    print(f"Screenshots saved to: {os.path.join(output_dir, 'screenshots')}")
+    return True
+
+
 def latest_model_path(model_type):
     candidates = [
         path for path in models_dir().glob(f"ag-*-{model_type}-*")
@@ -1278,10 +1302,15 @@ def parse_args():
     parser.add_argument("--no-shap", action="store_true", help="Skip SHAP visualizations.")
     parser.add_argument("--use-calibrated", action="store_true", help="Use calibrated predictions when calibrator.pkl exists.")
     parser.add_argument("--output-dir", default=None, help="Directory for prediction images and CSVs.")
+    parser.add_argument("--screenshots", action="store_true", help="Create PNG screenshots from generated HTML visualizations when Chrome is available.")
     return parser.parse_args()
 
 
 def cli():
+    compat_class = install_pathlib_pickle_compatibility()
+    if compat_class:
+        print(f"[runtime] Enabled cross-OS pathlib pickle compatibility for {compat_class} artifacts")
+
     args = parse_args()
     # Which event to predict
     upcoming_number = args.upcoming_number
@@ -1344,7 +1373,7 @@ def cli():
         # Single model: load scaler from root directory
         scaler_path = os.path.join(model_path, 'scaler.pkl')
         if os.path.exists(scaler_path):
-            scaler = joblib.load(scaler_path)
+            scaler = load_joblib_artifact(scaler_path)
             print(f"Loaded scaler from root directory (single model)")
         else:
             raise FileNotFoundError(f"scaler.pkl not found in {model_path}")
@@ -1742,10 +1771,7 @@ def cli():
     #conf_parlays = create_conf_parlays(results)
     #kelly_parlays = create_parlays(results)
     
-    # Take screenshots of all visualizations
-    print("\nTaking screenshots of visualizations...")
-    take_screenshots(ss_output_dir)
-    print(f"Screenshots saved to: {os.path.join(ss_output_dir, 'screenshots')}")
+    maybe_take_screenshots(ss_output_dir, enabled=args.screenshots)
 
 
 if __name__ == "__main__":

--- a/scripts/docker_smoke.py
+++ b/scripts/docker_smoke.py
@@ -113,8 +113,10 @@ def check_runtime_dependencies(container_name: str) -> None:
     code = textwrap.dedent(
         """
         import importlib.util
+        import pickle
         import sys
 
+        from libs.modeling.portable_artifacts import install_pathlib_pickle_compatibility
         from libs.modeling.runtime_dependencies import prediction_runtime_dependency_report
 
         present = [name for name in ("pytest", "pytest_mock") if importlib.util.find_spec(name) is not None]
@@ -133,7 +135,15 @@ def check_runtime_dependencies(container_name: str) -> None:
             )
             raise SystemExit(f"prediction runtime dependencies missing: {missing}")
 
-        print("runtime dependency check ok: pytest absent, pytest_mock absent, kaleido 0.2.1, prediction imports present")
+        windows_path_pickle = (
+            b"\\x80\\x04\\x953\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x8c\\x07pathlib\\x94"
+            b"\\x8c\\x0bWindowsPath\\x94\\x93\\x94\\x8c\\x03C:\\\\\\x94\\x8c\\x06models"
+            b"\\x94\\x8c\\x02ag\\x94\\x87\\x94R\\x94."
+        )
+        install_pathlib_pickle_compatibility()
+        pickle.loads(windows_path_pickle)
+
+        print("runtime dependency check ok: pytest absent, pytest_mock absent, kaleido 0.2.1, prediction imports present, cross-OS pathlib pickles load")
         """
     ).strip()
     result = _docker_exec(container_name, ["/app/.venv/bin/python", "-c", code], timeout=30)

--- a/tests/test_inference/test_predict.py
+++ b/tests/test_inference/test_predict.py
@@ -28,6 +28,7 @@ from predict import (
     calculate_expected_value,
     has_positive_ev,
     latest_model_path,
+    maybe_take_screenshots,
     parse_manual_odds_json,
     apply_manual_odds,
 )
@@ -513,7 +514,7 @@ class TestModelFunctions:
     """Test suite for model-related functions"""
     
     @patch('autogluon.tabular.TabularPredictor')
-    @patch('predict.joblib.load')
+    @patch('predict.load_joblib_artifact')
     @patch('predict.os.path.exists')
     def test_load_model_and_calibrator(self, mock_exists, mock_joblib_load, mock_predictor):
         """Test model and calibrator loading"""
@@ -641,6 +642,22 @@ class TestModelFunctions:
         second_call_args = mock_model.predict_proba.call_args_list[1][0][0]
         assert 'sample_weight' in second_call_args.columns
         assert (second_call_args['sample_weight'] == 1.0).all()
+
+    @patch("predict.take_screenshots")
+    def test_maybe_take_screenshots_is_opt_in(self, mock_take_screenshots):
+        """Prediction should not require browser screenshots by default."""
+        result = maybe_take_screenshots("/tmp/predictions", enabled=False)
+
+        assert result is False
+        mock_take_screenshots.assert_not_called()
+
+    @patch("predict.take_screenshots", side_effect=RuntimeError("chrome unavailable"))
+    def test_maybe_take_screenshots_does_not_fail_prediction(self, mock_take_screenshots):
+        """Screenshot failures should not fail already-written prediction outputs."""
+        result = maybe_take_screenshots("/tmp/predictions", enabled=True)
+
+        assert result is False
+        mock_take_screenshots.assert_called_once_with("/tmp/predictions")
 
 
 class TestDataProcessingFunctions:
@@ -802,7 +819,7 @@ class TestIntegrationScenarios:
         assert len(fighter_dfs['fighter a']) == 1
         assert list(fighter_dfs['fighter a'].columns) == ['feature1', 'feature2', 'feature3']
     
-    @patch('predict.joblib.load')
+    @patch('predict.load_joblib_artifact')
     @patch('predict.load_model_and_calibrator')
     def test_full_prediction_workflow(self, mock_load_model, mock_joblib_load):
         """Test complete prediction workflow from features to results"""
@@ -1048,7 +1065,7 @@ class TestErrorHandling:
         assert calculate_expected_value("invalid", "invalid") == 0.0
     
     @patch('autogluon.tabular.TabularPredictor')
-    @patch('predict.joblib.load')  
+    @patch('predict.load_joblib_artifact')  
     @patch('predict.os.path.exists')
     def test_model_loading_error_handling(self, mock_exists, mock_joblib_load, mock_predictor):
         """Test model loading with various error conditions"""

--- a/tests/test_modeling/test_portable_artifacts.py
+++ b/tests/test_modeling/test_portable_artifacts.py
@@ -1,0 +1,59 @@
+import os
+import pathlib
+import pickle
+
+import pandas as pd
+import pytest
+
+from libs.modeling.portable_artifacts import (
+    install_pathlib_pickle_compatibility,
+    pathlib_pickle_compatibility,
+)
+from predict import get_predictions
+
+
+WINDOWS_PATH_PICKLE = (
+    b"\x80\x04\x953\x00\x00\x00\x00\x00\x00\x00\x8c\x07pathlib\x94"
+    b"\x8c\x0bWindowsPath\x94\x93\x94\x8c\x03C:\\\x94\x8c\x06models"
+    b"\x94\x8c\x02ag\x94\x87\x94R\x94."
+)
+
+
+def test_pathlib_pickle_compatibility_loads_windows_paths_on_posix():
+    if os.name == "nt":
+        pytest.skip("WindowsPath pickles already load natively on Windows.")
+
+    with pytest.raises(NotImplementedError):
+        pickle.loads(WINDOWS_PATH_PICKLE)
+
+    with pathlib_pickle_compatibility():
+        loaded = pickle.loads(WINDOWS_PATH_PICKLE)
+
+    assert isinstance(loaded, pathlib.PosixPath)
+    assert loaded.parts[-2:] == ("models", "ag")
+
+
+def test_install_pathlib_pickle_compatibility_supports_lazy_prediction_unpickles():
+    class LazyArtifactModel:
+        def predict_proba(self, data):
+            pickle.loads(WINDOWS_PATH_PICKLE)
+            return pd.DataFrame({0: [0.4], 1: [0.6]}, index=data.index)
+
+    if os.name != "nt":
+        with pytest.raises(NotImplementedError):
+            LazyArtifactModel().predict_proba(pd.DataFrame({"feature": [1]}))
+
+    source_name = "PosixPath" if os.name == "nt" else "WindowsPath"
+    original_path_class = getattr(pathlib, source_name)
+    try:
+        install_pathlib_pickle_compatibility()
+        result = get_predictions(
+            LazyArtifactModel(),
+            calibrator=None,
+            scaled_X_df=pd.DataFrame({"feature": [1]}),
+            use_calibrated=False,
+        )
+    finally:
+        setattr(pathlib, source_name, original_path_class)
+
+    assert result.iloc[0][1] == 0.6


### PR DESCRIPTION
## Summary
- add a reusable AutoGluon artifact compatibility layer for pathlib objects serialized on another OS
- enable that compatibility through prediction-time lazy model loading, scaler/calibrator loading, and walk-forward ensemble loading
- make screenshot generation opt-in/best-effort so ChromeDriver cannot fail an otherwise successful prediction
- extend Docker smoke coverage and focused prediction tests for cross-OS pickle behavior

## Verification
- `uv run pytest`
- `uv run python scripts/docker_smoke.py --image mma-ai-web:latest --timeout 120`
- Docker prediction with latest model: `/app/.venv/bin/python predict.py --model-type win --upcoming-number 1 --no-shap --odds --no-manual-odds --output-dir /app/data/predictions/latest-runtime-smoke` wrote `fight_predictions.csv` and `prediction_stats.csv` and exited 0