### PR TITLE
[codex] Build LLM analytics Python reports

### DIFF
--- a/docs/LLM_ANALYTICS_SYSTEM_PROMPT_SPEC.md
+++ b/docs/LLM_ANALYTICS_SYSTEM_PROMPT_SPEC.md
@@ -1,0 +1,140 @@
+# Data Tab LLM Analytics System Prompt Spec
+
+## Goal
+
+Make the Data tab feel like a careful MMA analytics workbench: a user asks a
+natural-language question, the app supplies a rich MMA feature-store system
+prompt plus live schema context, the LLM returns a safe read-only query and a
+guarded Python analysis script, and the dashboard displays a polished report
+with narrative, SQL provenance, row preview, and Plotly visuals.
+
+This spec also defines the copyable prompt exposed in the dashboard through the
+`Copy Analytics Agent System Prompt` button so a user can paste the same
+context into a coding agent.
+
+## Research Basis
+
+The design follows these current agent and analytics-agent practices:
+
+- [OpenAI practical guide to building agents](https://openai.com/business/guides-and-resources/a-practical-guide-to-building-ai-agents/): use clear orchestration patterns, typed application code, guardrails, and tracing rather than relying on one free-form prompt.
+- [OpenAI structured outputs](https://developers.openai.com/api/docs/guides/structured-outputs): prefer schema-shaped output for machine-consumed results; JSON mode alone does not guarantee schema adherence.
+- [OpenAI prompt engineering](https://developers.openai.com/api/docs/guides/prompt-engineering): use role/context separation, explicit success criteria, examples, and structured output expectations.
+- [Anthropic multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system): subagents help when work can be decomposed into independent branches; each delegated task needs an objective, source/tool guidance, boundaries, and output format.
+- [Anthropic building effective agents](https://www.anthropic.com/engineering/building-effective-agents): start simple, evaluate thoroughly, keep the agent-computer interface explicit, and add multi-step agentic complexity only when it earns its keep.
+- [Microsoft Fabric data-agent best practices](https://learn.microsoft.com/en-us/fabric/data-science/data-agent-configuration-best-practices): narrow the domain, define business terms, prioritize sources, document joins, and include representative query logic.
+- [Snowflake Cortex Analyst semantic-view best practices](https://www.snowflake.com/en/developers/guides/best-practices-semantic-views-cortex-analyst/): use business-focused descriptions, clear relationships, metrics/filters, verified queries, and iterative test sets.
+- [Plotly Python graph objects](https://plotly.com/python/graph-objects/): let analysis scripts create real Plotly figures, then serialize those figures to portable JSON for browser rendering.
+- [Text-to-SQL security guidance](https://www.dpriver.com/blog/text-to-sql-security-10-risks-before-production-deployment/): validate generated SQL deterministically before execution; read-only credentials are helpful but not sufficient by themselves.
+
+## Product Shape
+
+User flow:
+
+1. User opens the Data tab.
+2. User optionally clicks `Copy Analytics Agent System Prompt` and pastes it
+   into a coding agent or external LLM.
+3. User asks a question in the Analytics box.
+4. Backend sends the canonical analytics system prompt, live schema context,
+   user question, and output constraints to the configured LLM.
+5. LLM returns strict JSON with a `python` script string.
+6. Backend validates the script, runs it in a restricted Python environment, and
+   lets the script fetch Postgres data only through guarded `run_sql()`.
+7. Frontend displays an organized analytics report: explanation, metrics, SQL
+   disclosure, row preview, and one or more chart cards.
+
+Current app hooks:
+
+- Prompt source: `libs/web/analytics_prompt.py`.
+- Prompt copy endpoint: `GET /api/data/analytics/system-prompt`.
+- LLM prompt assembly: `libs/web/analytics.py`.
+- Data-tab copy button: `libs/web/static/index.html` and `libs/web/static/app.js`.
+- Data-tab report renderer: `renderAnalyticsReport()` and
+  `renderPlotlyCharts()` in `libs/web/static/app.js`.
+
+## Subagent Pattern
+
+Do not require subagents for the first dashboard implementation. Use a single
+LLM call with deterministic Python and SQL validation for the normal path.
+Subagents become useful when a host coding agent, research agent, or future
+dashboard backend can parallelize bounded checks:
+
+- Schema scout: inspect available tables and columns, then return only relevant
+  schema snippets.
+- Python analyst: draft a short analysis script using `run_sql`, pandas, and
+  Plotly.
+- SQL verifier: check table names, joins, temporal leakage, aggregation grain,
+  row explosion risk, and forbidden statement types.
+- Chart designer: choose the most useful Plotly chart for the analysis output.
+- Results critic: flag missing data, weak sample size, null-heavy features, and
+  whether the answer overclaims.
+
+The coordinator should pass each subagent a narrow objective, explicit output
+format, and clear stop condition. The coordinator owns the final response and
+must not blindly concatenate subagent outputs.
+
+## Prompt Contract
+
+The canonical prompt should be treated as a system or developer message when a
+provider supports that. In the current dashboard, it is also included inside the
+JSON user payload under `system_prompt` so every configured provider receives
+the same context.
+
+The LLM must return strict JSON only:
+
+```json
+{
+  "python": "df = run_sql(\"SELECT weightclass, COUNT(*) AS fights FROM features.fight_mapping GROUP BY weightclass ORDER BY fights DESC\", limit=100)\\nset_answer(\"Lightweight and welterweight have the largest fight counts in this database slice.\")\\nset_rows(df)\\nfig = px.bar(df, x=\"weightclass\", y=\"fights\", title=\"Fight count by weight class\")\\nfig.update_layout(xaxis_title=\"Weight class\", yaxis_title=\"Fights\")\\nadd_chart(fig)"
+}
+```
+
+The backend executes the script only in a restricted analytics runner. The script
+cannot import modules, read/write files, call network APIs, or connect to the
+database directly. All data must come from Postgres through `run_sql()`, which
+enforces one read-only `SELECT` or `WITH` statement in a read-only transaction.
+The script may call `set_answer()`, `set_rows()`, and `add_chart()` to create the
+final UI report.
+
+## Canonical System Prompt
+
+The full canonical prompt lives in `libs/web/analytics_prompt.py` and is exposed
+verbatim by `GET /api/data/analytics/system-prompt`. It is kept in code so the
+dashboard copy button and the live LLM request always share one source of truth.
+
+The critical output contract is:
+
+```json
+{
+  "python": "df = run_sql(\"SELECT ...\", limit=100)\\nset_answer(\"...\")\\nset_rows(df)\\nadd_chart(px.bar(df, x=\"...\", y=\"...\"))"
+}
+```
+
+The prompt tells the LLM about the feature store, feature suffixes, odds fields,
+opponent-adjusted performance, and the restricted runner helpers: `pd`, `np`,
+`px`, `go`, `run_sql`, `set_answer`, `set_rows`, and `add_chart`.
+
+## Implementation Notes
+
+- Keep the prompt source in code so the copy button and LLM path share one
+  canonical string.
+- Keep live schema context dynamic. The prompt teaches the conceptual schema;
+  `database_context()` supplies the actual tables and columns currently present.
+- Continue validating generated SQL with `is_read_only_sql()` and database
+  read-only transactions. The LLM Python runner must use Postgres through
+  `run_sql()` only; any manual SQL fallback path should remain separate from
+  generated LLM analysis.
+- Add structured-output retries later if providers support JSON schema, not just
+  JSON object mode.
+- Add a verified-question suite with 10 to 20 examples covering feature drift,
+  sparse features, matchup feature deltas, odds/EV, calibration buckets, and
+  raw scrape quality.
+
+## Acceptance Criteria
+
+- Data tab has a self-explanatory copy button labeled
+  `Copy Analytics Agent System Prompt`.
+- Clicking the button copies the canonical prompt from
+  `/api/data/analytics/system-prompt`.
+- LLM analytics prompt assembly includes the same canonical prompt.
+- SQL execution remains read-only and bounded.
+- Tests cover the API endpoint, UI wiring, local icon shim, and prompt inclusion
+  in LLM requests.

--- a/libs/web/analytics.py
+++ b/libs/web/analytics.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 import sqlite3
 from typing import Any
 
+import numpy as np
 import pandas as pd
 import plotly.express as px
+import plotly.graph_objects as go
 from sqlalchemy import create_engine, inspect, text
 
 from libs.paths import PROJECT_ROOT, data_file, database_url
+from libs.web.analytics_prompt import analytics_system_prompt
 from libs.web.llm import llm_config, llm_config_hint, llm_generate_text
 
 
@@ -20,6 +24,98 @@ FORBIDDEN_SQL = re.compile(
     re.IGNORECASE,
 )
 POSTGRES_ANALYTICS_STATEMENT_TIMEOUT_MS = 30_000
+MAX_ANALYTICS_CHARTS = 4
+MAX_ANALYTICS_CODE_CHARS = 12_000
+MAX_ANALYTICS_DISPLAY_ROWS = 200
+FORBIDDEN_PYTHON_NAMES = {
+    "__import__",
+    "breakpoint",
+    "compile",
+    "dir",
+    "eval",
+    "exec",
+    "getattr",
+    "globals",
+    "help",
+    "input",
+    "locals",
+    "open",
+    "setattr",
+    "vars",
+}
+FORBIDDEN_PYTHON_REFERENCES = {
+    "builtins",
+    "importlib",
+    "io",
+    "os",
+    "pathlib",
+    "requests",
+    "shutil",
+    "socket",
+    "subprocess",
+    "sys",
+}
+FORBIDDEN_PYTHON_ATTRIBUTES = {
+    "connect",
+    "dispose",
+    "execute",
+    "read_clipboard",
+    "read_csv",
+    "read_excel",
+    "read_feather",
+    "read_fwf",
+    "read_gbq",
+    "read_hdf",
+    "read_html",
+    "read_json",
+    "read_orc",
+    "read_parquet",
+    "read_pickle",
+    "read_sql",
+    "read_sql_query",
+    "read_spss",
+    "read_stata",
+    "read_table",
+    "read_xml",
+    "remove",
+    "rmdir",
+    "run",
+    "system",
+    "to_csv",
+    "to_excel",
+    "to_feather",
+    "to_json",
+    "to_parquet",
+    "to_pickle",
+    "to_sql",
+    "unlink",
+    "write_html",
+    "write_image",
+    "write_json",
+}
+SAFE_BUILTINS = {
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "bool": bool,
+    "dict": dict,
+    "enumerate": enumerate,
+    "float": float,
+    "int": int,
+    "len": len,
+    "list": list,
+    "max": max,
+    "min": min,
+    "pow": pow,
+    "range": range,
+    "round": round,
+    "set": set,
+    "sorted": sorted,
+    "str": str,
+    "sum": sum,
+    "tuple": tuple,
+    "zip": zip,
+}
 
 
 def is_read_only_sql(sql: str) -> bool:
@@ -67,7 +163,10 @@ def run_analytics(question: str, sql: str | None = None, max_rows: int = 100) ->
     config = llm_config()
     if sql is None and config and config.is_configured:
         generated = _ask_llm(question)
-        sql = generated.get("sql")
+        python_code = generated.get("python")
+        if not isinstance(python_code, str) or not python_code.strip():
+            raise ValueError("Analytics LLM response must include a python script.")
+        return _run_python_analysis(python_code, max_rows)
 
     if not sql:
         context = database_context()
@@ -76,41 +175,170 @@ def run_analytics(question: str, sql: str | None = None, max_rows: int = 100) ->
             "schema_context": context,
             "sql": None,
             "rows": [],
-            "chart": None,
+            "charts": [],
         }
 
     if not is_read_only_sql(sql):
         raise ValueError("Only a single read-only SELECT or WITH query is allowed.")
 
     df = _execute_read_only_query(sql, max_rows)
-    raw_chart_spec = (generated or {}).get("chart")
-    chart_spec = raw_chart_spec if isinstance(raw_chart_spec, dict) else _default_chart_spec(df)
-    chart = _build_chart(df, chart_spec)
+    chart_specs = _chart_specs_from_generated(generated, df)
+    charts = [_build_chart(df, chart_spec) for chart_spec in chart_specs]
+    charts = [chart for chart in charts if chart is not None]
     return {
         "answer": (generated or {}).get("answer", "Query executed."),
         "sql": sql,
         "rows": df.to_dict(orient="records"),
         "columns": list(df.columns),
-        "chart": chart,
+        "charts": charts,
     }
 
 
 def _ask_llm(question: str) -> dict[str, Any]:
     prompt = {
-        "task": "Return strict JSON with answer, sql, and optional chart keys for read-only MMA analytics.",
+        "system_prompt": analytics_system_prompt(),
+        "task": "Return strict JSON with one python key for a guarded database analytics script.",
         "question": question,
         "schema_context": database_context(),
         "project_guidance": _agent_guidance_excerpt(),
         "constraints": [
-            "SQL must be a single SELECT or WITH query.",
-            "Prefer features schema tables and finalized model_data/training outputs when Postgres is available.",
-            "When schema_context.source is finalized_csvs, query table names such as training_data, training_data_dec, or prediction_data directly.",
+            "Return JSON only with a python string. Do not return answer/sql/rows/charts directly.",
+            "The python script runs in a restricted environment with pd, np, px, go, run_sql, set_answer, set_rows, and add_chart already available.",
+            "Do not import modules, read files, write files, use network calls, or connect to the database directly.",
+            "All data access must use run_sql(sql, limit=...). run_sql only allows one read-only SELECT or WITH query and executes it against Postgres.",
+            "The script must call set_answer(text), set_rows(dataframe_or_records), and add_chart(fig_or_plotly_dict) for each useful chart.",
+            "Prefer features schema tables and finalized model_data tables when Postgres is available.",
             "Never mutate data.",
-            "For charts, either return {type, x, y} using result column names, or a Plotly JSON object with data and layout.",
             "Return JSON only, with no Markdown fences.",
         ],
     }
     return parse_llm_json(llm_generate_text(prompt, json_mode=True))
+
+
+def _run_python_analysis(code: str, max_rows: int) -> dict[str, Any]:
+    """Run a guarded LLM-authored analytics script against Postgres."""
+    code = _normalize_python_analysis_code(code)
+    _validate_python_analysis_code(code)
+    output: dict[str, Any] = {
+        "answer": "",
+        "sql": None,
+        "rows": [],
+        "columns": [],
+        "charts": [],
+    }
+    state: dict[str, Any] = {"last_df": None}
+
+    def run_sql(sql: str, limit: int | None = None) -> pd.DataFrame:
+        bounded_limit = max(1, min(int(limit or max_rows), max_rows))
+        df = _execute_database_only_read_only_query(sql, bounded_limit)
+        state["last_df"] = df
+        output["sql"] = sql.strip().rstrip(";")
+        return df
+
+    def set_answer(value: Any) -> None:
+        output["answer"] = str(value)
+
+    def set_rows(value: Any) -> None:
+        df = _value_to_dataframe(value)
+        output["rows"] = df.head(MAX_ANALYTICS_DISPLAY_ROWS).to_dict(orient="records")
+        output["columns"] = list(df.columns)
+
+    def add_chart(value: Any) -> None:
+        if len(output["charts"]) >= MAX_ANALYTICS_CHARTS:
+            return
+        chart = _plotly_value_to_chart(value)
+        if chart:
+            output["charts"].append(chart)
+
+    globals_dict: dict[str, Any] = {
+        "__builtins__": SAFE_BUILTINS,
+        "add_chart": add_chart,
+        "go": go,
+        "np": np,
+        "pd": pd,
+        "px": px,
+        "run_sql": run_sql,
+        "set_answer": set_answer,
+        "set_rows": set_rows,
+    }
+    exec(compile(code, "<analytics-llm-python>", "exec"), globals_dict, {})
+
+    if not output["rows"] and isinstance(state.get("last_df"), pd.DataFrame):
+        set_rows(state["last_df"])
+    if not output["answer"]:
+        output["answer"] = "Analysis executed."
+    return output
+
+
+def _validate_python_analysis_code(code: str) -> None:
+    code = _normalize_python_analysis_code(code)
+    if len(code) > MAX_ANALYTICS_CODE_CHARS:
+        raise ValueError(f"Analytics Python script is too long; limit is {MAX_ANALYTICS_CODE_CHARS} characters.")
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as exc:
+        raise ValueError(f"Analytics Python script has invalid syntax: {exc}") from exc
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            raise ValueError("Analytics Python scripts may not import modules.")
+        if isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.Delete, ast.Global, ast.Nonlocal, ast.With, ast.AsyncWith)):
+            raise ValueError(f"Analytics Python scripts may not use {type(node).__name__}.")
+        if isinstance(node, ast.Name):
+            if node.id.startswith("__") or node.id in FORBIDDEN_PYTHON_REFERENCES:
+                raise ValueError(f"Analytics Python scripts may not reference {node.id}.")
+        if isinstance(node, ast.Attribute):
+            if node.attr.startswith("__") or node.attr in FORBIDDEN_PYTHON_ATTRIBUTES:
+                raise ValueError(f"Analytics Python scripts may not access attribute {node.attr}.")
+        if isinstance(node, ast.Call):
+            call_name = _call_name(node.func)
+            if call_name in FORBIDDEN_PYTHON_NAMES or call_name in FORBIDDEN_PYTHON_REFERENCES:
+                raise ValueError(f"Analytics Python scripts may not call {call_name}.")
+
+
+def _normalize_python_analysis_code(code: str) -> str:
+    """Tolerate common provider formatting around generated Python strings."""
+    stripped = code.strip()
+    fenced = re.match(r"^```(?:python|py)?\s*(.*?)\s*```$", stripped, flags=re.IGNORECASE | re.DOTALL)
+    if fenced:
+        stripped = fenced.group(1).strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {'"', "'"}:
+        try:
+            decoded = json.loads(stripped)
+            if isinstance(decoded, str):
+                stripped = decoded.strip()
+        except json.JSONDecodeError:
+            pass
+    if "\\n" in stripped and "\n" not in stripped:
+        stripped = stripped.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\t", "    ")
+    return stripped
+
+
+def _call_name(func: ast.AST) -> str | None:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _value_to_dataframe(value: Any) -> pd.DataFrame:
+    if isinstance(value, pd.DataFrame):
+        return value
+    if isinstance(value, pd.Series):
+        return value.to_frame()
+    return pd.DataFrame(value)
+
+
+def _plotly_value_to_chart(value: Any) -> dict[str, Any] | None:
+    if hasattr(value, "to_json") and callable(value.to_json):
+        chart = json.loads(value.to_json())
+    elif isinstance(value, dict) and isinstance(value.get("data"), list):
+        chart = {"data": value["data"], "layout": value.get("layout") if isinstance(value.get("layout"), dict) else {}}
+    else:
+        return None
+    chart["layout"] = _polished_layout(chart.get("layout"))
+    return chart
 
 
 def parse_llm_json(text_response: str) -> dict[str, Any]:
@@ -163,6 +391,18 @@ def _execute_read_only_query(sql: str, max_rows: int) -> pd.DataFrame:
                 raise RuntimeError(
                     f"Database query failed, and CSV fallback query failed. Available CSV tables: {table_names}. CSV error: {csv_exc}"
                 ) from csv_exc
+
+
+def _execute_database_only_read_only_query(sql: str, max_rows: int) -> pd.DataFrame:
+    stripped_sql = sql.strip().rstrip(";")
+    if not is_read_only_sql(stripped_sql):
+        raise ValueError("Only a single read-only SELECT or WITH query is allowed.")
+    bounded_sql = f"SELECT * FROM ({stripped_sql}) AS analytics_query LIMIT :max_rows"
+    engine = create_engine(database_url())
+    try:
+        return _execute_database_read_only_query(engine, bounded_sql, max_rows)
+    finally:
+        engine.dispose()
 
 
 def _execute_database_read_only_query(engine: Any, bounded_sql: str, max_rows: int) -> pd.DataFrame:
@@ -229,17 +469,22 @@ def _default_chart_spec(df: pd.DataFrame) -> dict[str, str] | None:
     return {"type": "bar", "x": x_column, "y": numeric[0]}
 
 
+def _chart_specs_from_generated(generated: dict[str, Any] | None, df: pd.DataFrame) -> list[dict[str, Any]]:
+    if isinstance(generated, dict) and isinstance(generated.get("charts"), list):
+        chart_specs = [chart for chart in generated["charts"] if isinstance(chart, dict)]
+        return chart_specs[:MAX_ANALYTICS_CHARTS]
+
+    default_chart = _default_chart_spec(df)
+    return [default_chart] if default_chart else []
+
+
 def _build_chart(df: pd.DataFrame, spec: dict[str, Any] | None) -> dict[str, Any] | None:
     if not spec:
         return None
     if isinstance(spec.get("data"), list):
         return {
             "data": spec["data"],
-            "layout": {
-                "template": "plotly_white",
-                "margin": {"l": 36, "r": 16, "t": 28, "b": 36},
-                **(spec.get("layout") if isinstance(spec.get("layout"), dict) else {}),
-            },
+            "layout": _polished_layout(spec.get("layout")),
         }
     chart_type = spec.get("type", "bar")
     x_column = spec.get("x")
@@ -247,16 +492,39 @@ def _build_chart(df: pd.DataFrame, spec: dict[str, Any] | None) -> dict[str, Any
     if x_column not in df.columns or (y_column and y_column not in df.columns):
         return None
 
+    labels = {
+        column: label
+        for column, label in ((x_column, spec.get("x_label")), (y_column, spec.get("y_label")))
+        if column and label
+    }
     if chart_type == "line" and y_column:
-        fig = px.line(df, x=x_column, y=y_column)
+        fig = px.line(df, x=x_column, y=y_column, labels=labels)
     elif chart_type == "scatter" and y_column:
-        fig = px.scatter(df, x=x_column, y=y_column)
+        fig = px.scatter(df, x=x_column, y=y_column, labels=labels)
     elif chart_type == "histogram":
-        fig = px.histogram(df, x=x_column)
+        fig = px.histogram(df, x=x_column, labels=labels)
+    elif chart_type == "area" and y_column:
+        fig = px.area(df, x=x_column, y=y_column, labels=labels)
+    elif chart_type == "box":
+        fig = px.box(df, x=x_column, y=y_column, labels=labels)
     elif y_column:
-        fig = px.bar(df, x=x_column, y=y_column)
+        fig = px.bar(df, x=x_column, y=y_column, labels=labels)
     else:
         return None
 
-    fig.update_layout(template="plotly_white", margin={"l": 36, "r": 16, "t": 28, "b": 36})
+    fig.update_layout(_polished_layout({"title": spec.get("title")} if spec.get("title") else None))
     return json.loads(fig.to_json())
+
+
+def _polished_layout(layout: Any | None) -> dict[str, Any]:
+    provided = layout if isinstance(layout, dict) else {}
+    return {
+        "template": "plotly_white",
+        "paper_bgcolor": "#ffffff",
+        "plot_bgcolor": "#ffffff",
+        "font": {"family": "Inter, system-ui, sans-serif", "color": "#16201f"},
+        "colorway": ["#0f766e", "#b42318", "#2563eb", "#92400e", "#7c3aed", "#475569"],
+        "margin": {"l": 44, "r": 20, "t": 44, "b": 44},
+        "hovermode": "closest",
+        **provided,
+    }

--- a/libs/web/analytics_prompt.py
+++ b/libs/web/analytics_prompt.py
@@ -1,0 +1,203 @@
+"""Reusable prompt text for MMA AI dashboard analytics."""
+
+from __future__ import annotations
+
+
+ANALYTICS_AGENT_SYSTEM_PROMPT_VERSION = "2026-06-01"
+
+
+ANALYTICS_AGENT_SYSTEM_PROMPT = """
+You are the MMA AI Data Tab analytics agent. Your job is to help a user ask
+clear questions about UFC fight data, write safe Python analytics scripts that
+read from the Postgres feature store, and explain the result with compact,
+useful charts.
+
+Operating principles:
+
+- Be a careful fight-data analyst with a locked-down Python and SQL workbench.
+- Prefer governed local data over guesses. If a requested metric is not present,
+  say what is missing and provide the closest safe alternative.
+- Never mutate data. Every SQL string passed to run_sql() must begin with SELECT
+  or WITH. Do not emit INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, COPY,
+  TRUNCATE, VACUUM, ANALYZE, GRANT, REVOKE, SET, RESET, EXECUTE, REFRESH,
+  MERGE, ATTACH, DETACH, REINDEX, CHECKPOINT, stored procedure calls, or
+  multiple semicolon-separated statements.
+- Prevent temporal leakage. Any historical aggregate used to explain or compare
+  a fight must be based only on rows before that fight's event_date. Do not use
+  post-fight outcomes or current-fight performance as pre-fight evidence.
+- Keep the answer honest about sample size, missing odds, null-heavy columns,
+  and any assumptions made by the analysis script.
+- Use explicit joins and aliases. Do not rely on ambiguous natural joins.
+- Keep exploratory outputs bounded. Aggregate first when possible; select raw
+  rows only when the user specifically asks for examples.
+- Use the user's wording, but normalize it to the database's feature language.
+- If the question is ambiguous, return a conservative query plus assumptions,
+  or state the clarification needed in the answer field.
+
+Source priority:
+
+1. For model-facing analytics, prefer finalized model_data tables when present.
+2. For understanding a feature family, use feature-specific tables in the
+   features schema, such as features.sig_str, features.td, features.ctrl,
+   features.odds, or features.style.
+3. For row-level engineered features, use features.fight_stats_derived.
+4. Use features.fight_stats_fe only to inspect raw UFCStats scrape quality.
+
+Database organization:
+
+- features is the authoritative feature-store schema.
+- model_data contains finalized model-ready outputs when present.
+- public is infrastructure or ad hoc data only.
+- features.fighter_mapping maps fighter_id to fighter_name plus profile fields
+  such as fighter_dob, fighter_height, fighter_reach, fighter_stance, and
+  fighter_weight.
+- features.event_mapping maps event_id to event_date and event_location.
+- features.fight_mapping maps fight_id to event_id, fighter1_id, fighter2_id,
+  weightclass, weightclass_encoded, method, details, end_round, end_time,
+  time_format, and result.
+- features.fight_stats_fe contains raw UFCStats fight rows with fighter_id,
+  event_id, round-level stats, total fight stats, result metadata, fighter IDs,
+  and event IDs.
+- features.fight_stats_derived is an enhanced copy of fight_stats_fe after base
+  calculators add derived fields and sparse raw values are smoothed/replaced.
+- Feature-specific tables are created from fight_stats_derived and then layered
+  with historical calculations. Common examples: age, reach, height, ape,
+  ufcage, days_since_last_fight, sig_str, strikes, head, body, leg, distance,
+  clinch, ground, td, sub, rev, ctrl, kd, ko, decision, win, odds, and style.
+
+Feature families and plain-language meanings:
+
+- age: fighter age at the fight date.
+- reach: reach in inches when available.
+- height: height in inches when available.
+- ape: reach minus height.
+- ufcage: years since the fighter's first UFC fight.
+- days_since_last_fight: rest or layoff entering the bout.
+- weightclass and weightclass_encoded: fight division metadata.
+- sig_str: significant strikes.
+- strikes: all recorded strikes.
+- head, body, leg: significant-strike target locations.
+- distance, clinch, ground: significant-strike positions.
+- td: takedowns.
+- sub or sub_att: submission attempts; sub_land means completed submission win
+  event when present.
+- rev: reversals.
+- ctrl: control time, typically seconds.
+- kd: knockdowns.
+- ko: knockout or technical knockout outcome signal.
+- decision: decision outcome signal.
+- win: win outcome signal.
+- odds: betting market features from BestFightOdds-derived data.
+- style: composite style metrics built from lower-level volume, accuracy,
+  wrestling, control, finishing, and absorbed-pressure features.
+
+Important suffixes:
+
+- _rd1 means first-round value.
+- _smooth means Bayesian-smoothed value before raw replacement.
+- _total means cumulative total.
+- _acc means landed divided by attempted.
+- _def means defensive rate against opponent attempts.
+- _per_min means rate per fight minute.
+- _ratio means normalized share or proportion, such as stat divided by total
+  fights or bounded fighter share.
+- _per means a conversion metric, such as ko_per_sig_str_land or td_per_ctrl.
+- _pressure means first-round share relative to total.
+- _avg means historical simple average.
+- _dec_avg means time-decayed historical average. Treat it as already
+  past-only for historical rows.
+- _mad means median absolute deviation.
+- _sdev means standard deviation.
+- _wc_mean means weight-class baseline mean.
+- _wc_mad means weight-class median absolute deviation.
+- _minimum_mad means floor used to avoid unstable adjusted-performance scores.
+- _opp means what opponents historically achieved against the fighter.
+- _adjperf means opponent-adjusted performance, usually a reliability-weighted
+  z-score comparing observed performance to expected performance against that
+  opponent.
+- _dec_adjperf means time-decayed opponent-adjusted performance.
+- _diff means fighter1 minus fighter2. Positive values favor fighter1 for that
+  feature; negative values favor fighter2.
+
+Odds guidance:
+
+- features.odds contains opening_odds, closing_odds, sevenday_opening_odds,
+  ip_opening_odds, ip_closing_odds, sevenday_ip_opening_odds,
+  vigless_ip_opening_odds, vigless_ip_closing_odds, and
+  sevenday_vigless_ip_opening_odds.
+- ip_* fields are implied probabilities from decimal odds.
+- vigless_ip_* fields normalize the two sides of a fight to remove bookmaker
+  overround.
+- Dashboard prediction odds are not model inputs. They are used to calculate
+  market probability, AI odds, expected value, and pick edge.
+- For EV-style analytics, define edge as AI probability minus market implied
+  probability when both fields exist.
+
+Recommended query patterns:
+
+- Join fight-level feature tables to event and fighter names through
+  features.fight_mapping, features.event_mapping, and features.fighter_mapping.
+- For fighter1/fighter2 comparisons, join feature tables twice: once on
+  fighter1_id and once on fighter2_id, then compute fighter1 minus fighter2.
+- For time trends, aggregate by date_trunc('year', event_date) or event_date.
+- For drift, compare recent events or years against earlier windows using
+  averages, null rates, and standard deviations.
+- For calibration, bucket predicted probabilities and compare mean predicted
+  probability to realized win rate.
+- For sparse-feature checks, compute count, non-null count, null rate, mean, and
+  standard deviation by feature family, year, or weight class.
+- For matchup explanations, rank *_diff columns by absolute value and explain
+  whether positive values favor fighter1 or fighter2.
+
+Python analysis rules:
+
+- Return Python code for the dashboard's restricted analytics runner. Do not
+  return precomputed answer/sql/rows/charts JSON.
+- The runner provides pd, np, px, go, run_sql(sql, limit=None), set_answer(text),
+  set_rows(dataframe_or_records), and add_chart(fig_or_plotly_dict).
+- Do not import modules. Do not use files, network calls, subprocesses, direct
+  database connections, environment variables, or secrets.
+- All data must come from Postgres through run_sql(). Do not query CSV files.
+- run_sql only accepts one read-only SELECT or WITH query and executes it in a
+  read-only Postgres transaction.
+- Use pandas for grouping, bucketing, joins, reshaping, correlations, and
+  descriptive statistics after fetching appropriately scoped database rows.
+- Use Plotly Express or graph_objects to create charts. Call add_chart(fig) for
+  each high-signal visualization.
+- Prefer one to three high-signal charts: bar for ranked categories, line for
+  trends, scatter for relationships, histogram for distributions, box for
+  comparisons, area for cumulative trends, and heatmap for matrices.
+- Use clear titles and axis labels. The host will render the charts as an
+  organized visual report.
+
+Output contract:
+
+Return strict JSON only. No Markdown fences, no prose outside JSON.
+
+The object must contain:
+
+- python: a single Python script string for the restricted analytics runner.
+  The script must call set_answer(), set_rows(), and add_chart() when a chart is
+  useful.
+
+Example output:
+
+{"python": "df = run_sql(\"SELECT weightclass, COUNT(*) AS fights FROM features.fight_mapping GROUP BY weightclass ORDER BY fights DESC\", limit=100)\\nset_answer(\"Lightweight and welterweight have the largest fight counts in this database slice.\")\\nset_rows(df)\\nfig = px.bar(df, x=\"weightclass\", y=\"fights\", title=\"Fight count by weight class\")\\nfig.update_layout(xaxis_title=\"Weight class\", yaxis_title=\"Fights\")\\nadd_chart(fig)"}
+
+When useful, also include:
+
+- assumptions: short list of assumptions.
+- warnings: short list of data quality, leakage, scope, or sample-size warnings.
+- followups: short list of natural next questions.
+
+For complex requests, internally decompose the work into data-source selection,
+SQL generation, safety verification, result interpretation, and visualization.
+If your host provides subagents, delegate only bounded side tasks such as schema
+inspection, chart critique, or SQL verification, then synthesize one final
+Python script in the JSON contract above.
+""".strip()
+
+
+def analytics_system_prompt() -> str:
+    """Return the stable analytics prompt that users can copy from the dashboard."""
+    return ANALYTICS_AGENT_SYSTEM_PROMPT

--- a/libs/web/app.py
+++ b/libs/web/app.py
@@ -12,6 +12,7 @@ from fastapi.staticfiles import StaticFiles
 
 from libs.paths import data_dir
 from libs.web.analytics import run_analytics
+from libs.web.analytics_prompt import ANALYTICS_AGENT_SYSTEM_PROMPT_VERSION, analytics_system_prompt
 from libs.web.evaluations import summarize_model_evaluation
 from libs.web.jobs import JobManager
 from libs.web.models import (
@@ -107,6 +108,10 @@ def create_app() -> FastAPI:
     @app.get("/api/data/analytics/status")
     def analytics_status() -> dict:
         return get_analytics_status()
+
+    @app.get("/api/data/analytics/system-prompt")
+    def analytics_prompt() -> dict:
+        return {"version": ANALYTICS_AGENT_SYSTEM_PROMPT_VERSION, "system_prompt": analytics_system_prompt()}
 
     @app.get("/api/train/defaults")
     def train_defaults() -> dict:

--- a/libs/web/static/app.js
+++ b/libs/web/static/app.js
@@ -24,14 +24,106 @@ function renderJson(target, value) {
   qs(target).textContent = typeof value === "string" ? value : JSON.stringify(value, null, 2);
 }
 
-function renderPlotlyChart(target, chart) {
+function chartTitle(chart, index) {
+  const title = chart?.layout?.title;
+  if (typeof title === "string" && title.trim()) return title;
+  if (title?.text) return title.text;
+  return `Chart ${index + 1}`;
+}
+
+function normalizeAnalyticsCharts(result) {
+  if (Array.isArray(result?.charts)) return result.charts.filter((chart) => chart?.data && chart?.layout);
+  return [];
+}
+
+function renderPlotlyCharts(target, charts) {
   const element = qs(target);
-  if (!chart) {
-    if (window.Plotly) Plotly.purge(element);
-    element.innerHTML = "";
+  if (window.Plotly) {
+    element.querySelectorAll(".analytics-plot").forEach((plot) => Plotly.purge(plot));
+    if (element.classList.contains("js-plotly-plot")) Plotly.purge(element);
+  }
+  element.innerHTML = "";
+
+  const normalizedCharts = (Array.isArray(charts) ? charts : charts ? [charts] : [])
+    .filter((chart) => chart?.data && chart?.layout);
+  if (!normalizedCharts.length) {
+    element.classList.remove("has-charts");
     return;
   }
-  Plotly.newPlot(element, chart.data, chart.layout, { responsive: true });
+
+  element.classList.add("has-charts");
+  normalizedCharts.forEach((chart, index) => {
+    const title = chartTitle(chart, index);
+    const card = document.createElement("article");
+    card.className = "analytics-chart-card";
+    card.innerHTML = `<div class="analytics-chart-title">${escapeHtml(title)}</div>`;
+    const plot = document.createElement("div");
+    plot.className = "analytics-plot";
+    plot.setAttribute("aria-label", title);
+    card.appendChild(plot);
+    element.appendChild(card);
+    Plotly.newPlot(plot, chart.data, chart.layout, { responsive: true, displaylogo: false });
+  });
+}
+
+function renderAnalyticsRows(rows, columns) {
+  if (!rows.length) return `<div class="analytics-empty">No rows returned for this query.</div>`;
+  const visibleColumns = (columns.length ? columns : Object.keys(rows[0])).slice(0, 7);
+  const extraColumns = Math.max((columns.length || Object.keys(rows[0]).length) - visibleColumns.length, 0);
+  const visibleRows = rows.slice(0, 8);
+  const header = visibleColumns.map((column) => `<th>${escapeHtml(column)}</th>`).join("");
+  const body = visibleRows.map((row) => (
+    `<tr>${visibleColumns.map((column) => `<td>${escapeHtml(row[column])}</td>`).join("")}</tr>`
+  )).join("");
+  const noteParts = [];
+  if (rows.length > visibleRows.length) noteParts.push(`${rows.length - visibleRows.length} more rows`);
+  if (extraColumns > 0) noteParts.push(`${extraColumns} more columns`);
+  const note = noteParts.length ? `<div class="analytics-table-note">${escapeHtml(noteParts.join(", "))}</div>` : "";
+  return `
+    <div class="analytics-table-wrap">
+      <table class="analytics-table">
+        <thead><tr>${header}</tr></thead>
+        <tbody>${body}</tbody>
+      </table>
+    </div>
+    ${note}
+  `;
+}
+
+function renderAnalyticsReport(result) {
+  const output = qs("#analytics-output");
+  const rows = Array.isArray(result?.rows) ? result.rows : [];
+  const columns = Array.isArray(result?.columns) ? result.columns : [];
+  const charts = normalizeAnalyticsCharts(result);
+  const paragraphs = String(result?.answer || "Query executed.")
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean)
+    .map((paragraph) => `<p>${escapeHtml(paragraph)}</p>`)
+    .join("");
+  const sql = result?.sql ? escapeHtml(result.sql) : "No SQL was returned.";
+  output.innerHTML = `
+    <div class="analytics-answer">
+      <span class="analytics-kicker">Analysis</span>
+      ${paragraphs || "<p>Query executed.</p>"}
+    </div>
+    <div class="analytics-metrics">
+      <div><strong>${rows.length}</strong><span>Rows</span></div>
+      <div><strong>${columns.length}</strong><span>Columns</span></div>
+      <div><strong>${charts.length}</strong><span>Charts</span></div>
+    </div>
+    <details class="analytics-sql">
+      <summary>SQL</summary>
+      <pre>${sql}</pre>
+    </details>
+    ${renderAnalyticsRows(rows, columns)}
+  `;
+  renderPlotlyCharts("#analytics-chart", charts);
+}
+
+function renderAnalyticsError(message) {
+  qs("#analytics-output").innerHTML = `<div class="analytics-error">${escapeHtml(message)}</div>`;
+  renderPlotlyCharts("#analytics-chart", []);
 }
 
 function escapeHtml(value) {
@@ -163,6 +255,32 @@ function setLogText(selector, value) {
   if (!element) return;
   element.textContent = value;
   element.scrollTop = element.scrollHeight;
+}
+
+async function copyText(value) {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return;
+    } catch (_error) {
+      // Fall through to the textarea fallback for browsers that expose the API
+      // but block write permission in this context.
+    }
+  }
+  const textArea = document.createElement("textarea");
+  textArea.value = value;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.left = "-9999px";
+  document.body.appendChild(textArea);
+  textArea.select();
+  try {
+    if (!document.execCommand("copy")) {
+      throw new Error("Clipboard copy was blocked.");
+    }
+  } finally {
+    textArea.remove();
+  }
 }
 
 function listValue(value) {
@@ -554,6 +672,16 @@ function wireData() {
   qs("#refresh-status").addEventListener("click", async () => {
     await Promise.allSettled([refreshStatus(), refreshReadiness(), refreshAnalyticsStatus()]);
   });
+  qs("#copy-analytics-system-prompt").addEventListener("click", async () => {
+    const status = qs("#analytics-copy-status");
+    try {
+      const payload = await api("/api/data/analytics/system-prompt");
+      await copyText(payload.system_prompt);
+      status.textContent = "Analytics agent system prompt copied.";
+    } catch (error) {
+      status.textContent = `Could not copy prompt: ${error.message}`;
+    }
+  });
   qs("#run-data").addEventListener("click", async () => {
     try {
       const payload = {
@@ -583,11 +711,9 @@ function wireData() {
           max_rows: Number(qs("#analytics-max-rows").value || 100),
         }),
       });
-      renderJson("#analytics-output", { answer: result.answer, sql: result.sql, rows: result.rows });
-      renderPlotlyChart("#analytics-chart", result.chart);
+      renderAnalyticsReport(result);
     } catch (error) {
-      renderJson("#analytics-output", error.message);
-      renderPlotlyChart("#analytics-chart", null);
+      renderAnalyticsError(error.message);
     }
   });
 }

--- a/libs/web/static/icons.js
+++ b/libs/web/static/icons.js
@@ -5,6 +5,7 @@
     "bar-chart-3": '<path d="M3 3v18h18"/><path d="M7 16V9"/><path d="M12 16V5"/><path d="M17 16v-4"/>',
     brain: '<path d="M8.5 14.5A3.5 3.5 0 0 1 5 11c0-1.6 1.1-3 2.6-3.4A3.6 3.6 0 0 1 14 5.3 3.7 3.7 0 0 1 19 8.8a3.7 3.7 0 0 1-.9 7.2H16"/><path d="M12 5v14"/><path d="M8 19a3 3 0 0 1-3-3v-1"/><path d="M16 19a3 3 0 0 0 3-3v-1"/><path d="M8.5 10.5h2"/><path d="M13.5 10.5h2"/><path d="M9 15h2"/><path d="M13 15h2"/>',
     "calendar-search": '<path d="M8 2v4"/><path d="M16 2v4"/><rect x="3" y="4" width="18" height="17" rx="2"/><path d="M3 10h18"/><circle cx="11" cy="15" r="2.5"/><path d="M13 17l2 2"/>',
+    copy: '<rect width="14" height="14" x="8" y="8" rx="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>',
     database: '<ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v6c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/><path d="M4 11v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6"/>',
     "message-square-text": '<path d="M21 15a2 2 0 0 1-2 2H8l-5 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><path d="M8 8h8"/><path d="M8 12h6"/>',
     play: '<polygon points="6,4 20,12 6,20"/>',

--- a/libs/web/static/index.html
+++ b/libs/web/static/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>MMA AI</title>
-    <link rel="stylesheet" href="/static/styles.css" />
+    <link rel="stylesheet" href="/static/styles.css?v=analytics-python-20260601" />
     <script src="/vendor/plotly.min.js"></script>
-    <script src="/static/icons.js"></script>
+    <script src="/static/icons.js?v=analytics-python-20260601"></script>
   </head>
   <body>
     <header class="topbar">
@@ -46,9 +46,15 @@
           <section class="surface">
             <div class="section-head">
               <h2>Analytics</h2>
-              <button id="run-analytics" class="primary"><i data-lucide="sparkles"></i><span>Ask</span></button>
+              <div class="section-actions">
+                <button id="copy-analytics-system-prompt" class="secondary" title="Copy the full MMA analytics system prompt for coding agents">
+                  <i data-lucide="copy"></i><span>Copy Analytics Agent System Prompt</span>
+                </button>
+                <button id="run-analytics" class="primary"><i data-lucide="sparkles"></i><span>Ask</span></button>
+              </div>
             </div>
             <p id="analytics-status" class="field-note analytics-status">Checking analytics setup...</p>
+            <p id="analytics-copy-status" class="field-note copy-status" aria-live="polite"></p>
             <textarea id="analytics-question" rows="4" placeholder="Which features changed most over the last five UFC events?"></textarea>
             <textarea id="analytics-sql" rows="4" placeholder="Optional read-only SQL"></textarea>
             <details>
@@ -59,8 +65,8 @@
                 </label>
               </div>
             </details>
-            <div id="analytics-output" class="result"></div>
-            <div id="analytics-chart" class="chart"></div>
+            <div id="analytics-output" class="result analytics-report" aria-live="polite"></div>
+            <div id="analytics-chart" class="chart analytics-chart-grid"></div>
           </section>
         </div>
       </section>
@@ -158,6 +164,6 @@
     </main>
 
     <footer id="job-strip"></footer>
-    <script src="/static/app.js"></script>
+    <script src="/static/app.js?v=analytics-python-20260601"></script>
   </body>
 </html>

--- a/libs/web/static/styles.css
+++ b/libs/web/static/styles.css
@@ -216,6 +216,13 @@ main {
   margin-bottom: 14px;
 }
 
+.section-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .section-head.compact {
   margin-top: 14px;
 }
@@ -346,6 +353,119 @@ summary {
   white-space: pre-wrap;
 }
 
+.analytics-report {
+  max-height: none;
+  overflow: visible;
+  color: var(--ink);
+  white-space: normal;
+  display: grid;
+  gap: 12px;
+}
+
+.analytics-report:empty {
+  display: none;
+}
+
+.analytics-answer {
+  display: grid;
+  gap: 6px;
+  padding: 12px 14px;
+  border-left: 4px solid var(--accent);
+  background: #f8fafc;
+}
+
+.analytics-answer p {
+  margin: 0;
+  line-height: 1.55;
+}
+
+.analytics-kicker,
+.analytics-table-note {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.analytics-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.analytics-metrics div {
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.analytics-metrics strong {
+  display: block;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.analytics-metrics span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.analytics-sql {
+  margin: 0;
+  padding-top: 0;
+}
+
+.analytics-sql pre {
+  max-height: 180px;
+  overflow: auto;
+  margin: 10px 0 0;
+  white-space: pre-wrap;
+}
+
+.analytics-table-wrap {
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.analytics-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.analytics-table th,
+.analytics-table td {
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+
+.analytics-table th {
+  background: #f8fafc;
+  color: var(--ink);
+  font-size: 12px;
+}
+
+.analytics-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.analytics-empty,
+.analytics-error {
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--muted);
+}
+
+.analytics-error {
+  border-color: #fecaca;
+  color: #991b1b;
+}
+
 .eval-summary {
   display: grid;
   gap: 14px;
@@ -440,6 +560,39 @@ summary {
 
 .chart {
   min-height: 320px;
+}
+
+.analytics-chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 12px;
+  min-height: 0;
+}
+
+.analytics-chart-grid:not(.has-charts) {
+  display: none;
+}
+
+.analytics-chart-card {
+  display: flex;
+  min-height: 360px;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.analytics-chart-title {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.analytics-plot {
+  min-height: 320px;
+  flex: 1;
 }
 
 .prediction-output {
@@ -794,6 +947,10 @@ summary {
   color: #92400e;
 }
 
+.copy-status {
+  min-height: 16px;
+}
+
 .muted {
   color: var(--muted);
 }
@@ -870,6 +1027,16 @@ footer {
   .top-actions {
     flex-direction: column-reverse;
     align-items: flex-end;
+  }
+
+  .section-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .section-actions {
+    justify-content: flex-start;
+    width: 100%;
   }
 
   .readiness-badge {

--- a/tests/e2e/test_data_tab_analytics_prompt.py
+++ b/tests/e2e/test_data_tab_analytics_prompt.py
@@ -1,0 +1,337 @@
+import os
+import socket
+import time
+from contextlib import closing
+from threading import Thread
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import pytest
+from fastapi.testclient import TestClient
+
+from libs.web.app import create_app
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _start_uvicorn(app, port: int):
+    import uvicorn
+
+    server = uvicorn.Server(
+        uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="off")
+    )
+    thread = Thread(target=server.run, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{port}"
+    for _ in range(100):
+        try:
+            with urlopen(f"{base_url}/api/health", timeout=0.5) as response:
+                if response.status == 200:
+                    return server, thread, base_url
+        except (OSError, URLError):
+            time.sleep(0.05)
+    server.should_exit = True
+    thread.join(timeout=5)
+    raise AssertionError("Uvicorn test server did not start")
+
+
+def _fake_status(tmp_path):
+    raw_dir = tmp_path / "data" / "raw" / "ufcstats"
+    data_dir = tmp_path / "data"
+    return {
+        "project_root": str(tmp_path),
+        "database_url": "postgresql://postgres:***@localhost:5432/mma-ai",
+        "raw_data_dir": str(raw_dir),
+        "data_dir": str(data_dir),
+        "raw_csvs": {
+            "competitions": {"path": str(raw_dir / "competitions.csv"), "rows": 1},
+            "individuals": {"path": str(raw_dir / "individuals.csv"), "rows": 1},
+        },
+        "model_csvs": {
+            "prediction_data": {"path": str(data_dir / "prediction_data.csv"), "rows": 2},
+            "training_data": {"path": str(data_dir / "training_data.csv"), "rows": 2},
+            "training_data_dec": {"path": str(data_dir / "training_data_dec.csv"), "rows": 2},
+        },
+    }
+
+
+def test_data_tab_analytics_prompt_copy_smoke(monkeypatch, tmp_path):
+    """Smoke-test the Data tab analytics prompt route and static wiring."""
+    monkeypatch.setenv("MMA_AI_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr("libs.web.app.get_data_status", lambda: _fake_status(tmp_path))
+    monkeypatch.setattr(
+        "libs.web.app.get_readiness_status",
+        lambda: {"status": "ok", "ready": True, "checks": {"starter_model": {"ok": True}}},
+    )
+    client = TestClient(create_app())
+
+    dashboard = client.get("/")
+    assert dashboard.status_code == 200
+    assert 'id="copy-analytics-system-prompt"' in dashboard.text
+    assert "Copy Analytics Agent System Prompt" in dashboard.text
+
+    prompt_response = client.get("/api/data/analytics/system-prompt")
+    assert prompt_response.status_code == 200
+    prompt_payload = prompt_response.json()
+    assert prompt_payload["version"] == "2026-06-01"
+    assert "MMA AI Data Tab analytics agent" in prompt_payload["system_prompt"]
+    assert "_adjperf" in prompt_payload["system_prompt"]
+    assert "features.odds" in prompt_payload["system_prompt"]
+    assert "Return strict JSON only" in prompt_payload["system_prompt"]
+
+    app_js = client.get("/static/app.js").text
+    icons_js = client.get("/static/icons.js").text
+    assert 'api("/api/data/analytics/system-prompt")' in app_js
+    assert "function copyText(value)" in app_js
+    assert "Analytics agent system prompt copied." in app_js
+    assert "copy:" in icons_js
+
+
+def test_data_tab_browser_copies_analytics_system_prompt(monkeypatch, tmp_path):
+    """Real browser e2e for the Data tab analytics prompt copy workflow."""
+    if os.getenv("MMA_AI_RUN_BROWSER_E2E") != "1":
+        pytest.skip("Set MMA_AI_RUN_BROWSER_E2E=1 to run the Selenium browser e2e.")
+
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support import expected_conditions as ec
+    from selenium.webdriver.support.ui import WebDriverWait
+
+    monkeypatch.setenv("MMA_AI_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr("libs.web.app.get_data_status", lambda: _fake_status(tmp_path))
+    monkeypatch.setattr(
+        "libs.web.app.get_readiness_status",
+        lambda: {"status": "ok", "ready": True, "checks": {"starter_model": {"ok": True}}},
+    )
+    monkeypatch.setattr(
+        "libs.web.app.get_analytics_status",
+        lambda: {"configured": False, "mode": "sql_only", "hint": "test analytics status"},
+    )
+
+    server, thread, base_url = _start_uvicorn(create_app(), _free_port())
+    options = Options()
+    options.add_argument("--headless=new")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--window-size=1280,900")
+    driver = None
+    try:
+        driver = webdriver.Chrome(options=options)
+        wait = WebDriverWait(driver, 15)
+        driver.get(base_url)
+
+        copy_button = wait.until(ec.element_to_be_clickable((By.ID, "copy-analytics-system-prompt")))
+        assert "Copy Analytics Agent System Prompt" in copy_button.text
+        copy_button.click()
+
+        status = wait.until(ec.presence_of_element_located((By.ID, "analytics-copy-status")))
+        wait.until(ec.text_to_be_present_in_element((By.ID, "analytics-copy-status"), "copied"))
+        assert status.text == "Analytics agent system prompt copied."
+
+        prompt = driver.execute_script(
+            "return fetch('/api/data/analytics/system-prompt').then(r => r.json()).then(j => j.system_prompt)"
+        )
+        assert "MMA AI Data Tab analytics agent" in prompt
+        assert "_adjperf" in prompt
+        assert "features.odds" in prompt
+    finally:
+        if driver is not None:
+            driver.quit()
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+def test_data_tab_browser_renders_llm_analytics_report_with_charts(monkeypatch, tmp_path):
+    """Real browser e2e for asking an analytics question and rendering Plotly charts."""
+    if os.getenv("MMA_AI_RUN_BROWSER_E2E") != "1":
+        pytest.skip("Set MMA_AI_RUN_BROWSER_E2E=1 to run the Selenium browser e2e.")
+
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support import expected_conditions as ec
+    from selenium.webdriver.support.ui import WebDriverWait
+
+    monkeypatch.setenv("MMA_AI_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr("libs.web.app.get_data_status", lambda: _fake_status(tmp_path))
+    monkeypatch.setattr(
+        "libs.web.app.get_readiness_status",
+        lambda: {"status": "ok", "ready": True, "checks": {"starter_model": {"ok": True}}},
+    )
+    monkeypatch.setattr(
+        "libs.web.app.get_analytics_status",
+        lambda: {"configured": True, "provider": "test", "model": "fake-analytics", "mode": "llm"},
+    )
+
+    def fake_run_analytics(question, sql=None, max_rows=100):
+        assert "adjperf" in question.lower()
+        assert sql is None
+        assert max_rows == 100
+        first_chart = {
+            "data": [
+                {
+                    "type": "bar",
+                    "x": ["Lightweight", "Welterweight", "Middleweight"],
+                    "y": [0.48, 0.44, 0.41],
+                    "name": "Accuracy",
+                    "marker": {"color": ["#0f766e", "#2563eb", "#b42318"]},
+                }
+            ],
+            "layout": {
+                "title": {"text": "Significant strike accuracy by weight class"},
+                "xaxis": {"title": {"text": "Weight class"}},
+                "yaxis": {"title": {"text": "Accuracy"}},
+                "template": "plotly_white",
+            },
+        }
+        second_chart = {
+            "data": [
+                {
+                    "type": "scatter",
+                    "mode": "markers",
+                    "x": [28, 31, 17],
+                    "y": [0.48, 0.44, 0.41],
+                    "name": "Fight sample",
+                }
+            ],
+            "layout": {
+                "title": {"text": "Sample size versus accuracy"},
+                "xaxis": {"title": {"text": "Fights"}},
+                "yaxis": {"title": {"text": "Accuracy"}},
+                "template": "plotly_white",
+            },
+        }
+        return {
+            "answer": (
+                "Positive opponent-adjusted striking performance clusters highest at lightweight. "
+                "The plots separate ranking and sample-size context so the result is easier to trust."
+            ),
+            "sql": "select weightclass, avg_sig_str_acc, fight_count from features.sig_str_adjperf_summary",
+            "rows": [
+                {"weightclass": "Lightweight", "avg_sig_str_acc": 0.48, "fight_count": 28},
+                {"weightclass": "Welterweight", "avg_sig_str_acc": 0.44, "fight_count": 31},
+                {"weightclass": "Middleweight", "avg_sig_str_acc": 0.41, "fight_count": 17},
+            ],
+            "columns": ["weightclass", "avg_sig_str_acc", "fight_count"],
+            "charts": [first_chart, second_chart],
+        }
+
+    monkeypatch.setattr("libs.web.app.run_analytics", fake_run_analytics)
+
+    server, thread, base_url = _start_uvicorn(create_app(), _free_port())
+    options = Options()
+    options.add_argument("--headless=new")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--window-size=1280,1000")
+    driver = None
+    try:
+        driver = webdriver.Chrome(options=options)
+        wait = WebDriverWait(driver, 15)
+        driver.get(base_url)
+
+        question = wait.until(ec.presence_of_element_located((By.ID, "analytics-question")))
+        question.clear()
+        question.send_keys("Which adjperf striking features stand out by weight class?")
+        wait.until(ec.element_to_be_clickable((By.ID, "run-analytics"))).click()
+
+        wait.until(ec.text_to_be_present_in_element((By.ID, "analytics-output"), "Positive opponent-adjusted"))
+        wait.until(ec.text_to_be_present_in_element((By.ID, "analytics-output"), "Lightweight"))
+        wait.until(lambda active_driver: "features.sig_str_adjperf_summary" in active_driver.execute_script(
+            "return document.querySelector('#analytics-output').textContent"
+        ))
+        wait.until(lambda active_driver: active_driver.execute_script(
+            "return document.querySelectorAll('#analytics-chart .js-plotly-plot').length"
+        ) == 2)
+
+        assert driver.execute_script("return document.querySelectorAll('.analytics-chart-card').length") == 2
+        assert "Significant strike accuracy by weight class" in driver.page_source
+        assert "Sample size versus accuracy" in driver.page_source
+        assert driver.execute_script("return document.querySelectorAll('#analytics-chart .main-svg').length") >= 2
+        assert driver.execute_script("return document.querySelectorAll('#analytics-chart .barlayer .point').length") > 0
+    finally:
+        if driver is not None:
+            driver.quit()
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+def test_data_tab_browser_executes_sql_query_and_renders_plotly_chart(monkeypatch, tmp_path):
+    """Real browser e2e for executing an analytics query and rendering the generated chart."""
+    if os.getenv("MMA_AI_RUN_BROWSER_E2E") != "1":
+        pytest.skip("Set MMA_AI_RUN_BROWSER_E2E=1 to run the Selenium browser e2e.")
+
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support import expected_conditions as ec
+    from selenium.webdriver.support.ui import WebDriverWait
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "training_data.csv").write_text(
+        "\n".join(
+            [
+                "weightclass,avg_sig_str_acc,fight_count",
+                "Lightweight,0.48,28",
+                "Welterweight,0.44,31",
+                "Middleweight,0.41,17",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MMA_AI_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("DATABASE_URL", "postgresql://postgres:postgres@127.0.0.1:1/missing")
+    monkeypatch.setattr("libs.web.app.get_data_status", lambda: _fake_status(tmp_path))
+    monkeypatch.setattr(
+        "libs.web.app.get_readiness_status",
+        lambda: {"status": "ok", "ready": True, "checks": {"starter_model": {"ok": True}}},
+    )
+    monkeypatch.setattr(
+        "libs.web.app.get_analytics_status",
+        lambda: {"configured": False, "mode": "sql_only", "hint": "test analytics status"},
+    )
+
+    server, thread, base_url = _start_uvicorn(create_app(), _free_port())
+    options = Options()
+    options.add_argument("--headless=new")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--window-size=1280,1000")
+    driver = None
+    try:
+        driver = webdriver.Chrome(options=options)
+        wait = WebDriverWait(driver, 15)
+        driver.get(base_url)
+
+        wait.until(ec.presence_of_element_located((By.ID, "analytics-question"))).send_keys(
+            "Show significant strike accuracy by weight class."
+        )
+        wait.until(ec.presence_of_element_located((By.ID, "analytics-sql"))).send_keys(
+            "select weightclass, avg_sig_str_acc, fight_count from training_data order by avg_sig_str_acc desc"
+        )
+        wait.until(ec.element_to_be_clickable((By.ID, "run-analytics"))).click()
+
+        wait.until(ec.text_to_be_present_in_element((By.ID, "analytics-output"), "Query executed."))
+        wait.until(ec.text_to_be_present_in_element((By.ID, "analytics-output"), "Lightweight"))
+        wait.until(ec.text_to_be_present_in_element((By.ID, "analytics-output"), "3"))
+        wait.until(lambda active_driver: active_driver.execute_script(
+            "return document.querySelectorAll('#analytics-chart .js-plotly-plot').length"
+        ) == 1)
+
+        assert driver.execute_script("return document.querySelectorAll('.analytics-chart-card').length") == 1
+        assert driver.execute_script("return document.querySelectorAll('#analytics-chart .main-svg').length") >= 1
+        assert driver.execute_script("return document.querySelectorAll('#analytics-chart .barlayer .point').length") == 3
+        assert "avg_sig_str_acc" in driver.execute_script(
+            "return document.querySelector('#analytics-output').textContent"
+        )
+    finally:
+        if driver is not None:
+            driver.quit()
+        server.should_exit = True
+        thread.join(timeout=5)

--- a/tests/test_web/test_analytics.py
+++ b/tests/test_web/test_analytics.py
@@ -5,7 +5,16 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import pandas as pd
 
-from libs.web.analytics import _execute_read_only_query, database_context, is_read_only_sql, parse_llm_json, run_analytics
+from libs.web.analytics import (
+    _execute_read_only_query,
+    _run_python_analysis,
+    _validate_python_analysis_code,
+    database_context,
+    is_read_only_sql,
+    parse_llm_json,
+    run_analytics,
+)
+from libs.web.analytics_prompt import analytics_system_prompt
 
 
 def clear_llm_env(monkeypatch):
@@ -106,7 +115,8 @@ def test_run_analytics_executes_against_finalized_csv_fallback(monkeypatch, tmp_
     )
 
     assert result["rows"] == [{"fighter1_name": "a", "y_true": 1, "feature_diff": 0.4}]
-    assert result["chart"] is not None
+    assert "chart" not in result
+    assert result["charts"]
 
 
 def test_database_analytics_runs_inside_postgres_read_only_transaction(monkeypatch):
@@ -174,6 +184,75 @@ def test_database_analytics_runs_inside_postgres_read_only_transaction(monkeypat
     assert executed[-2:] == ["END", "DISPOSE"]
 
 
+def test_python_analytics_runner_uses_guarded_postgres_helper(monkeypatch):
+    captured = {}
+
+    def fake_database_query(sql, max_rows):
+        captured["sql"] = sql
+        captured["max_rows"] = max_rows
+        return pd.DataFrame(
+            [
+                {"weightclass": "Lightweight", "fights": 28},
+                {"weightclass": "Welterweight", "fights": 31},
+            ]
+        )
+
+    monkeypatch.setattr("libs.web.analytics._execute_database_only_read_only_query", fake_database_query)
+
+    result = _run_python_analysis(
+        "\n".join(
+            [
+                "df = run_sql('select weightclass, fights from features.fight_mapping', limit=50)",
+                "set_answer('Weight class summary')",
+                "set_rows(df)",
+                "fig = px.bar(df, x='weightclass', y='fights', title='Fights by weight class')",
+                "add_chart(fig)",
+            ]
+        ),
+        max_rows=100,
+    )
+
+    assert captured == {"sql": "select weightclass, fights from features.fight_mapping", "max_rows": 50}
+    assert result["answer"] == "Weight class summary"
+    assert result["sql"] == "select weightclass, fights from features.fight_mapping"
+    assert result["rows"][0]["weightclass"] == "Lightweight"
+    assert result["columns"] == ["weightclass", "fights"]
+    assert len(result["charts"]) == 1
+    assert result["charts"][0]["layout"]["title"]["text"] == "Fights by weight class"
+
+
+def test_python_analytics_runner_normalizes_escaped_llm_newlines(monkeypatch):
+    monkeypatch.setattr(
+        "libs.web.analytics._execute_database_only_read_only_query",
+        lambda _sql, _max_rows: pd.DataFrame([{"weightclass": "Lightweight", "fights": 28}]),
+    )
+
+    result = _run_python_analysis(
+        (
+            "df = run_sql('select weightclass, fights from features.fight_mapping', limit=50)\\n"
+            "set_answer('Escaped newlines work')\\n"
+            "set_rows(df)\\n"
+            "add_chart(px.bar(df, x='weightclass', y='fights', title='Escaped chart'))"
+        ),
+        max_rows=100,
+    )
+
+    assert result["answer"] == "Escaped newlines work"
+    assert result["rows"] == [{"weightclass": "Lightweight", "fights": 28}]
+    assert result["charts"][0]["layout"]["title"]["text"] == "Escaped chart"
+
+
+def test_python_analytics_runner_rejects_unsafe_code():
+    with pytest.raises(ValueError, match="import"):
+        _validate_python_analysis_code("import os\nset_answer('bad')")
+
+    with pytest.raises(ValueError, match="open"):
+        _validate_python_analysis_code("open('secret.txt').read()")
+
+    with pytest.raises(ValueError, match="read_csv"):
+        _validate_python_analysis_code("pd.read_csv('training_data.csv')")
+
+
 def test_run_analytics_uses_google_api_key_alias(monkeypatch, tmp_path):
     clear_llm_env(monkeypatch)
     monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
@@ -184,11 +263,18 @@ def test_run_analytics_uses_google_api_key_alias(monkeypatch, tmp_path):
         monkeypatch,
         json.dumps(
             {
-                "answer": "AI summary",
-                "sql": "select fighter1_name, wins from training_data",
-                "chart": {"type": "bar", "x": "fighter1_name", "y": "wins"},
+                "python": (
+                    "df = run_sql('select fighter1_name, wins from features.win_summary', limit=100)\n"
+                    "set_answer('AI summary')\n"
+                    "set_rows(df)\n"
+                    "add_chart(px.bar(df, x='fighter1_name', y='wins', title='Wins by fighter'))"
+                ),
             }
         ),
+    )
+    monkeypatch.setattr(
+        "libs.web.analytics._execute_database_only_read_only_query",
+        lambda _sql, _max_rows: pd.DataFrame([{"fighter1_name": "a", "wins": 3}]),
     )
 
     result = run_analytics("Show wins")
@@ -197,7 +283,39 @@ def test_run_analytics_uses_google_api_key_alias(monkeypatch, tmp_path):
     assert captured["model_name"] == "gemini-1.5-pro"
     assert result["answer"] == "AI summary"
     assert result["rows"] == [{"fighter1_name": "a", "wins": 3}]
-    assert result["chart"] is not None
+    assert "chart" not in result
+    assert result["charts"]
+
+
+def test_analytics_llm_prompt_includes_copyable_system_prompt(monkeypatch, tmp_path):
+    clear_llm_env(monkeypatch)
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
+    monkeypatch.setenv("MMA_AI_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DATABASE_URL", "postgresql://postgres:postgres@127.0.0.1:1/missing")
+    pd.DataFrame([{"fighter1_name": "a", "wins": 3}]).to_csv(tmp_path / "training_data.csv", index=False)
+    captured = install_fake_gemini(
+        monkeypatch,
+        json.dumps(
+            {
+                "python": (
+                    "df = run_sql('select fighter1_name, wins from features.win_summary', limit=100)\n"
+                    "set_answer('AI summary')\n"
+                    "set_rows(df)"
+                )
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "libs.web.analytics._execute_database_only_read_only_query",
+        lambda _sql, _max_rows: pd.DataFrame([{"fighter1_name": "a", "wins": 3}]),
+    )
+
+    run_analytics("Show wins")
+
+    payload = json.loads(captured["prompt"])
+    assert payload["system_prompt"] == analytics_system_prompt()
+    assert "_adjperf" in payload["system_prompt"]
+    assert "features.odds" in payload["system_prompt"]
 
 
 def test_run_analytics_uses_openai_compatible_llm(monkeypatch, tmp_path):
@@ -221,9 +339,12 @@ def test_run_analytics_uses_openai_compatible_llm(monkeypatch, tmp_path):
                         "message": {
                             "content": json.dumps(
                                 {
-                                    "answer": "AI summary",
-                                    "sql": "select fighter1_name, wins from training_data",
-                                    "chart": {"type": "bar", "x": "fighter1_name", "y": "wins"},
+                                    "python": (
+                                        "df = run_sql('select fighter1_name, wins from features.win_summary', limit=100)\n"
+                                        "set_answer('AI summary')\n"
+                                        "set_rows(df)\n"
+                                        "add_chart(px.bar(df, x='fighter1_name', y='wins', title='Wins by fighter'))"
+                                    ),
                                 }
                             )
                         }
@@ -236,6 +357,10 @@ def test_run_analytics_uses_openai_compatible_llm(monkeypatch, tmp_path):
         return FakeResponse()
 
     monkeypatch.setattr("libs.web.llm.requests.post", fake_post)
+    monkeypatch.setattr(
+        "libs.web.analytics._execute_database_only_read_only_query",
+        lambda _sql, _max_rows: pd.DataFrame([{"fighter1_name": "a", "wins": 3}]),
+    )
 
     result = run_analytics("Show wins")
 
@@ -247,7 +372,7 @@ def test_run_analytics_uses_openai_compatible_llm(monkeypatch, tmp_path):
     assert result["rows"] == [{"fighter1_name": "a", "wins": 3}]
 
 
-def test_run_analytics_accepts_llm_plotly_figure_spec(monkeypatch, tmp_path):
+def test_run_analytics_accepts_llm_plotly_figure_specs(monkeypatch, tmp_path):
     clear_llm_env(monkeypatch)
     monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
     monkeypatch.setenv("MMA_AI_DATA_DIR", str(tmp_path))
@@ -265,12 +390,13 @@ def test_run_analytics_accepts_llm_plotly_figure_spec(monkeypatch, tmp_path):
                         "message": {
                             "content": json.dumps(
                                 {
-                                    "answer": "AI chart",
-                                    "sql": "select fighter1_name, wins from training_data",
-                                    "chart": {
-                                        "data": [{"type": "bar", "x": ["a"], "y": [3], "name": "Wins"}],
-                                        "layout": {"title": "Wins by fighter"},
-                                    },
+                                    "python": (
+                                        "df = run_sql('select fighter1_name, wins from features.win_summary', limit=100)\n"
+                                        "set_answer('AI chart')\n"
+                                        "set_rows(df)\n"
+                                        "add_chart({'data': [{'type': 'bar', 'x': ['a'], 'y': [3], 'name': 'Wins'}], "
+                                        "'layout': {'title': 'Wins by fighter'}})"
+                                    ),
                                 }
                             )
                         }
@@ -279,15 +405,81 @@ def test_run_analytics_accepts_llm_plotly_figure_spec(monkeypatch, tmp_path):
             }
 
     monkeypatch.setattr("libs.web.llm.requests.post", lambda *_args, **_kwargs: FakeResponse())
+    monkeypatch.setattr(
+        "libs.web.analytics._execute_database_only_read_only_query",
+        lambda _sql, _max_rows: pd.DataFrame([{"fighter1_name": "a", "wins": 3}]),
+    )
 
     result = run_analytics("Show wins")
 
-    assert result["chart"]["data"] == [{"type": "bar", "x": ["a"], "y": [3], "name": "Wins"}]
-    assert result["chart"]["layout"]["title"] == "Wins by fighter"
-    assert result["chart"]["layout"]["template"] == "plotly_white"
+    assert "chart" not in result
+    assert result["charts"][0]["data"] == [{"type": "bar", "x": ["a"], "y": [3], "name": "Wins"}]
+    assert result["charts"][0]["layout"]["title"] == "Wins by fighter"
+    assert result["charts"][0]["layout"]["template"] == "plotly_white"
 
 
-def test_run_analytics_falls_back_when_llm_chart_spec_is_not_an_object(monkeypatch, tmp_path):
+def test_run_analytics_accepts_llm_charts_array(monkeypatch, tmp_path):
+    clear_llm_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.setenv("MMA_AI_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DATABASE_URL", "postgresql://postgres:postgres@127.0.0.1:1/missing")
+    pd.DataFrame(
+        [
+            {"weightclass": "Lightweight", "avg_sig_str_acc": 0.48, "fight_count": 28},
+            {"weightclass": "Welterweight", "avg_sig_str_acc": 0.44, "fight_count": 31},
+        ]
+    ).to_csv(tmp_path / "training_data.csv", index=False)
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": json.dumps(
+                                {
+                                    "python": (
+                                        "df = run_sql('select weightclass, avg_sig_str_acc, fight_count "
+                                        "from features.sig_str_summary', limit=100)\n"
+                                        "set_answer('Two coordinated charts')\n"
+                                        "set_rows(df)\n"
+                                        "add_chart(px.bar(df, x='weightclass', y='avg_sig_str_acc', "
+                                        "title='Significant strike accuracy by weight class'))\n"
+                                        "add_chart(px.scatter(df, x='fight_count', y='avg_sig_str_acc', "
+                                        "title='Volume versus accuracy'))"
+                                    ),
+                                }
+                            )
+                        }
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("libs.web.llm.requests.post", lambda *_args, **_kwargs: FakeResponse())
+    monkeypatch.setattr(
+        "libs.web.analytics._execute_database_only_read_only_query",
+        lambda _sql, _max_rows: pd.DataFrame(
+            [
+                {"weightclass": "Lightweight", "avg_sig_str_acc": 0.48, "fight_count": 28},
+                {"weightclass": "Welterweight", "avg_sig_str_acc": 0.44, "fight_count": 31},
+            ]
+        ),
+    )
+
+    result = run_analytics("Compare striking accuracy and volume")
+
+    assert result["answer"] == "Two coordinated charts"
+    assert "chart" not in result
+    assert len(result["charts"]) == 2
+    assert result["charts"][0]["layout"]["title"]["text"] == "Significant strike accuracy by weight class"
+    assert result["charts"][1]["layout"]["title"]["text"] == "Volume versus accuracy"
+    assert result["charts"][1]["layout"]["paper_bgcolor"] == "#ffffff"
+
+
+def test_run_analytics_requires_llm_python_script(monkeypatch, tmp_path):
     clear_llm_env(monkeypatch)
     monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
     monkeypatch.setenv("MMA_AI_DATA_DIR", str(tmp_path))
@@ -299,15 +491,12 @@ def test_run_analytics_falls_back_when_llm_chart_spec_is_not_an_object(monkeypat
             {
                 "answer": "AI summary",
                 "sql": "select fighter1_name, wins from training_data",
-                "chart": "not a chart object",
             }
         ),
     )
 
-    result = run_analytics("Show wins")
-
-    assert result["chart"] is not None
-    assert result["chart"]["data"][0]["type"] == "bar"
+    with pytest.raises(ValueError, match="python script"):
+        run_analytics("Show wins")
 
 
 def test_database_context_lists_finalized_csvs(monkeypatch, tmp_path):
@@ -324,7 +513,7 @@ def test_database_context_lists_finalized_csvs(monkeypatch, tmp_path):
 def test_parse_llm_json_accepts_markdown_fence():
     parsed = parse_llm_json(
         """```json
-        {"answer": "ok", "sql": "select * from training_data", "chart": {"type": "bar", "x": "fighter1_name", "y": "y_true"}}
+        {"answer": "ok", "sql": "select * from training_data", "charts": [{"type": "bar", "x": "fighter1_name", "y": "y_true"}]}
         ```"""
     )
 

--- a/tests/test_web/test_api.py
+++ b/tests/test_web/test_api.py
@@ -132,6 +132,19 @@ def test_analytics_status_endpoint_reports_non_secret_llm_status(monkeypatch):
     assert "api_key" not in payload
 
 
+def test_analytics_system_prompt_endpoint_returns_copyable_prompt():
+    client = TestClient(create_app())
+
+    response = client.get("/api/data/analytics/system-prompt")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["version"] == "2026-06-01"
+    assert "MMA AI Data Tab analytics agent" in payload["system_prompt"]
+    assert "_adjperf" in payload["system_prompt"]
+    assert "features.odds" in payload["system_prompt"]
+
+
 def test_data_refresh_endpoint_starts_background_job(monkeypatch):
     def fake_refresh(request):
         print("fake refresh stdout")

--- a/tests/test_web/test_static_ui.py
+++ b/tests/test_web/test_static_ui.py
@@ -10,7 +10,9 @@ def test_prediction_card_renderer_exposes_value_and_market_context():
     styles = (STATIC_DIR / "styles.css").read_text(encoding="utf-8")
 
     assert 'src="/vendor/plotly.min.js"' in html
-    assert 'src="/static/icons.js"' in html
+    assert 'src="/static/icons.js' in html
+    assert 'src="/static/app.js?v=analytics-python-20260601"' in html
+    assert 'href="/static/styles.css?v=analytics-python-20260601"' in html
     assert "cdn.plot.ly" not in html
     assert "unpkg.com" not in html
     assert "Pick" in app_js
@@ -248,16 +250,30 @@ def test_analytics_options_expose_bounded_row_limit():
 
     assert 'id="analytics-max-rows" type="number" min="1" max="1000" value="100"' in html
     assert 'id="analytics-status"' in html
+    assert 'id="analytics-copy-status"' in html
+    assert 'id="copy-analytics-system-prompt"' in html
+    assert "Copy Analytics Agent System Prompt" in html
+    assert 'api("/api/data/analytics/system-prompt")' in app_js
+    assert "function copyText(value)" in app_js
+    assert "Analytics agent system prompt copied." in app_js
     assert "max_rows: Number(qs(\"#analytics-max-rows\").value || 100)" in app_js
-    assert "function renderPlotlyChart(target, chart)" in app_js
+    assert "function renderAnalyticsReport(result)" in app_js
+    assert "function renderPlotlyCharts(target, charts)" in app_js
+    assert "normalizeAnalyticsCharts(result)" in app_js
+    assert "function renderPlotlyChart(target, chart)" not in app_js
     assert "function refreshAnalyticsStatus()" in app_js
     assert 'api("/api/data/analytics/status")' in app_js
     assert "LLM analytics ready" in app_js
     assert "Plotly.purge(element)" in app_js
-    assert 'renderPlotlyChart("#analytics-chart", result.chart)' in app_js
-    assert 'renderPlotlyChart("#analytics-chart", null)' in app_js
+    assert "renderAnalyticsReport(result)" in app_js
+    assert "renderAnalyticsError(error.message)" in app_js
+    assert 'id="analytics-output" class="result analytics-report"' in html
+    assert 'id="analytics-chart" class="chart analytics-chart-grid"' in html
     assert ".analytics-status.ready" in styles
     assert ".analytics-status.blocked" in styles
+    assert ".copy-status" in styles
+    assert ".analytics-chart-card" in styles
+    assert ".analytics-table" in styles
 
 
 def test_debug_logs_and_manual_event_odds_are_wired():


### PR DESCRIPTION
﻿## Summary
- Move Data tab LLM analytics from direct JSON SQL/chart output to a guarded Python analysis script contract.
- Add a versioned, copyable analytics agent system prompt and prompt endpoint.
- Render analytics output as a report with answer prose, row previews, SQL disclosure, and multiple Plotly chart cards.
- Add backend, API, static UI, and browser E2E coverage for the new prompt and report flow.

## Why
The previous Data tab prompt let the model return shallow SQL/chart JSON, which was too limited for exploratory MMA analytics. The new contract lets the model run safe pandas/Plotly transformations while enforcing database-only, read-only access through `run_sql()`.

## Validation
- `MMA_AI_RUN_BROWSER_E2E=1 uv run pytest tests/test_web/test_analytics.py tests/test_web/test_api.py tests/test_web/test_static_ui.py tests/e2e/test_data_tab_analytics_prompt.py -q`
- `node --check libs/web/static/app.js`
- Live Docker smoke test on `http://127.0.0.1:18000` confirmed an OpenAI-backed weight-class bar chart report.
