### PR TITLE
[codex] Add deployed readiness smoke check

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ If you already bootstrapped artifacts and only want to start the app:
 docker compose up --build db web
 ```
 
+After the stack is deployed, run the deployed readiness smoke check against the
+actual dashboard URL:
+
+```bash
+uv run mma-docker-smoke --deployed-url http://localhost:8000
+```
+
+If setup chose another web port, use that URL instead. This check verifies
+`/api/health`, requires `/api/readiness` to be ready, and confirms at least one
+compatible `win` model is discoverable before prediction.
+
 The Compose stack starts PostgreSQL 18.1 and initializes both the main `mma-ai`
 database and the auxiliary `odds` database used by odds-related workflows. The
 setup scripts restore the Hugging Face dumps into those databases. The web
@@ -224,6 +235,7 @@ docker compose up --build
 docker compose build web
 uv run mma-docker-smoke
 uv run mma-release-audit
+uv run mma-docker-smoke --deployed-url http://localhost:8000
 ```
 
 Optional real-browser Predict tab e2e, useful before release when Chrome is
@@ -245,7 +257,12 @@ fork a separate feature or prediction implementation.
 - `AGENTS.md` and `CLAUDE.md`: agent guidance for safe analytics, training,
   prediction, feature semantics, and test expectations.
 - `Dockerfile` and `docker-compose.yml`: public release runtime with Postgres
-  and the FastAPI dashboard.
+  and the FastAPI dashboard. After building the web image, `uv run
+  mma-docker-smoke` runs the container, checks `/api/health`, verifies the
+  dashboard HTML plus local Plotly/icon assets are served, and confirms the
+  runtime image does not include test tooling. After deploying a bootstrapped
+  Compose stack, `uv run mma-docker-smoke --deployed-url http://localhost:8000`
+  checks readiness and `win` model discovery against the running dashboard.
 - `libs/web`: FastAPI app, background jobs, web service adapters, analytics,
   evaluation summaries, and static UI.
 - `libs/scraping/ufcstats.py`: in-repo UFCStats scraper adapter.

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -45,6 +45,18 @@ dashboard at `http://localhost:8000`, or the alternate port printed by setup.
 The dashboard top bar mirrors this state with a `Ready` or `Setup incomplete`
 badge.
 
+For deployed-stack verification, run the readiness smoke check against the
+actual dashboard URL:
+
+```bash
+uv run mma-docker-smoke --deployed-url http://localhost:8000
+```
+
+Use the alternate web port printed by setup when port 8000 is unavailable. This
+check fails if `/api/readiness` is incomplete or if `/api/predict/models` cannot
+discover a compatible `win` model, so it catches the same conditions that block
+the Predict tab.
+
 ## Release Surface
 
 - Data tab: refresh UFCStats CSVs, rebuild PostgreSQL feature tables, write
@@ -140,6 +152,7 @@ uv run mma-release-audit
 docker compose config --quiet
 docker compose build web
 uv run mma-docker-smoke
+uv run mma-docker-smoke --deployed-url http://localhost:8000
 ```
 
 When Chrome is available, run the real-browser Predict tab e2e before release:
@@ -148,9 +161,11 @@ When Chrome is available, run the real-browser Predict tab e2e before release:
 MMA_AI_RUN_BROWSER_E2E=1 uv run pytest tests/e2e/test_predict_tab_next_event.py::test_predict_tab_browser_predicts_next_ufc_event -q
 ```
 
-The Docker smoke command starts the built web image, checks `/api/health`, fetches
-the dashboard HTML, `/vendor/plotly.min.js`, and `/static/icons.js` from inside
-the container, then verifies the runtime image does not include test tooling.
+The default Docker smoke command starts the built web image, checks
+`/api/health`, fetches the dashboard HTML, `/vendor/plotly.min.js`, and
+`/static/icons.js` from inside the container, then verifies the runtime image
+does not include test tooling. The deployed URL mode checks the running Compose
+stack's health, readiness, and `win` model discovery.
 
 Security and hygiene scans:
 

--- a/libs/web/services.py
+++ b/libs/web/services.py
@@ -67,6 +67,26 @@ def _count_csv_rows(path: Path) -> int | None:
         return sum(1 for _row in reader)
 
 
+def _csv_has_data_row(path: Path) -> int | None:
+    """Return 1 when a CSV has at least one data row without scanning it."""
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", newline="", encoding="utf-8", errors="replace") as handle:
+            reader = csv.reader(handle)
+            try:
+                next(reader)
+            except StopIteration:
+                return 0
+            try:
+                next(reader)
+            except StopIteration:
+                return 0
+    except (OSError, csv.Error):
+        return None
+    return 1
+
+
 def _read_csv_header(path: Path) -> tuple[set[str] | None, str | None]:
     if not path.exists():
         return None, None
@@ -185,8 +205,15 @@ def get_data_status() -> dict[str, Any]:
 
 def get_readiness_status() -> dict[str, Any]:
     """Return whether the dashboard has the artifacts needed for first use."""
-    status = get_data_status()
     checks: dict[str, dict[str, Any]] = {}
+    raw_dir = raw_ufcstats_dir()
+    readiness_csvs = {
+        ("raw_csvs", "competitions"): raw_dir / "competitions.csv",
+        ("raw_csvs", "individuals"): raw_dir / "individuals.csv",
+        ("model_csvs", "prediction_data"): data_file("prediction_data.csv"),
+        ("model_csvs", "training_data"): data_file("training_data.csv"),
+        ("model_csvs", "training_data_dec"): data_file("training_data_dec.csv"),
+    }
 
     for group, key in (
         ("raw_csvs", "competitions"),
@@ -195,7 +222,11 @@ def get_readiness_status() -> dict[str, Any]:
         ("model_csvs", "training_data"),
         ("model_csvs", "training_data_dec"),
     ):
-        entry = status[group][key]
+        path = readiness_csvs[(group, key)]
+        entry = {
+            "path": str(path),
+            "rows": _csv_has_data_row(path),
+        }
         checks[f"{key}_csv"] = _csv_readiness_check(
             entry,
             READINESS_CSV_REQUIRED_COLUMNS[(group, key)],

--- a/scripts/docker_smoke.py
+++ b/scripts/docker_smoke.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 import textwrap
 import time
 import uuid
 from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 
 DEFAULT_IMAGE = "mma-ai-web:latest"
@@ -79,6 +83,109 @@ def _docker_exec(container_name: str, command: list[str], *, timeout: int | None
 
 def _docker_exec_allow_failure(container_name: str, command: list[str], *, timeout: int | None = None) -> CommandResult:
     return _run_allow_failure(["docker", "exec", container_name, *command], timeout=timeout)
+
+
+def _join_url(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _fetch_json(base_url: str, path: str, *, timeout_seconds: int) -> tuple[int, dict]:
+    url = _join_url(base_url, path)
+    request = Request(url, headers={"Accept": "application/json"})
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            status = int(getattr(response, "status", 200))
+            body = response.read().decode("utf-8", errors="replace")
+    except HTTPError as exc:
+        status = exc.code
+        body = exc.read().decode("utf-8", errors="replace")
+    except URLError as exc:
+        raise SmokeError(f"Could not reach {url}: {exc}") from exc
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise SmokeError(f"Expected JSON from {url}, got: {body[:500]!r}") from exc
+    if not isinstance(payload, dict):
+        raise SmokeError(f"Expected JSON object from {url}, got: {type(payload).__name__}")
+    return status, payload
+
+
+def _readiness_payload(payload: dict) -> dict:
+    detail = payload.get("detail")
+    if isinstance(detail, dict) and "ready" in detail:
+        return detail
+    return payload
+
+
+def _format_readiness_failure(name: str, check: object) -> str:
+    if not isinstance(check, dict):
+        return f"{name} (invalid check payload)"
+
+    details: list[str] = []
+    missing_columns = check.get("missing_columns") or []
+    if missing_columns:
+        details.append(f"missing columns: {', '.join(str(column) for column in missing_columns)}")
+
+    if "rows" in check and not check.get("rows"):
+        details.append(f"rows: {check.get('rows')}")
+
+    missing_tables = check.get("missing_tables") or []
+    if missing_tables:
+        details.append(f"missing tables: {', '.join(str(table) for table in missing_tables)}")
+
+    if check.get("error"):
+        details.append(f"error: {check['error']}")
+
+    if name == "starter_model":
+        expected = check.get("expected") or "configured starter model"
+        models = check.get("models") or []
+        discovered = ", ".join(str(model) for model in models) if models else "none"
+        details.append(f"expected {expected}; discovered {discovered}")
+
+    suffix = "; ".join(details) if details else "not ok"
+    return f"{name} ({suffix})"
+
+
+def _failed_readiness_checks(readiness: dict) -> list[str]:
+    checks = readiness.get("checks")
+    if not isinstance(checks, dict):
+        return ["readiness checks unavailable"]
+    failures = [
+        _format_readiness_failure(name, check)
+        for name, check in checks.items()
+        if not isinstance(check, dict) or check.get("ok") is not True
+    ]
+    return failures or ["ready=false"]
+
+
+def check_deployed_readiness(base_url: str, model_type: str = "win", timeout_seconds: int = 30) -> None:
+    """Verify a deployed dashboard has the artifacts needed for prediction."""
+    health_status, health = _fetch_json(base_url, "/api/health", timeout_seconds=timeout_seconds)
+    if health_status != 200 or health.get("status") != "ok":
+        raise SmokeError(f"Deployed health check failed for {base_url}: HTTP {health_status} {health}")
+    print("[docker-smoke] deployed health ok")
+
+    readiness_status, readiness_response = _fetch_json(base_url, "/api/readiness", timeout_seconds=timeout_seconds)
+    readiness = _readiness_payload(readiness_response)
+    if readiness_status != 200 or readiness.get("ready") is not True:
+        failures = "\n".join(f"- {failure}" for failure in _failed_readiness_checks(readiness))
+        raise SmokeError(f"Deployed readiness check failed for {base_url}:\n{failures}")
+    print("[docker-smoke] deployed readiness ok")
+
+    query = urlencode({"model_type": model_type})
+    models_status, models_payload = _fetch_json(
+        base_url,
+        f"/api/predict/models?{query}",
+        timeout_seconds=timeout_seconds,
+    )
+    if models_status != 200:
+        raise SmokeError(f"Deployed model discovery failed for {base_url}: HTTP {models_status} {models_payload}")
+    models = models_payload.get("models") or []
+    if not models:
+        raise SmokeError(f"No {model_type} models found at {base_url}. Run setup again or provide a compatible model.")
+    model_names = ", ".join(str(model.get("name", "<unnamed>")) for model in models[:5] if isinstance(model, dict))
+    print(f"[docker-smoke] deployed {model_type} models ok: {model_names}")
 
 
 def wait_for_health(container_name: str, timeout_seconds: int) -> None:
@@ -192,14 +299,19 @@ def run_smoke(image: str = DEFAULT_IMAGE, timeout_seconds: int = 90, container_n
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Smoke-test a built MMA AI Docker web image.")
+    parser = argparse.ArgumentParser(description="Smoke-test a built MMA AI Docker image or a deployed dashboard.")
     parser.add_argument("--image", default=DEFAULT_IMAGE, help=f"Docker image to run. Default: {DEFAULT_IMAGE}")
     parser.add_argument("--timeout", type=int, default=90, help="Seconds to wait for /api/health. Default: 90")
     parser.add_argument("--container-name", help="Optional explicit container name for debugging.")
+    parser.add_argument("--deployed-url", help="Check an already deployed dashboard, for example http://127.0.0.1:8001.")
+    parser.add_argument("--model-type", default="win", help="Prediction model type to require in deployed mode. Default: win")
     args = parser.parse_args(argv)
 
     try:
-        run_smoke(args.image, args.timeout, args.container_name)
+        if args.deployed_url:
+            check_deployed_readiness(args.deployed_url, args.model_type, args.timeout)
+        else:
+            run_smoke(args.image, args.timeout, args.container_name)
     except SmokeError as exc:
         print(f"[docker-smoke] failed: {exc}", file=sys.stderr)
         return 1

--- a/tests/test_docker_smoke.py
+++ b/tests/test_docker_smoke.py
@@ -1,4 +1,7 @@
+import io
+import json
 import subprocess
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -8,6 +11,21 @@ from scripts import docker_smoke
 
 def completed(args, returncode=0, stdout="", stderr=""):
     return subprocess.CompletedProcess(args, returncode, stdout=stdout, stderr=stderr)
+
+
+class JsonResponse:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
 
 
 def test_docker_smoke_runs_container_checks_health_deps_and_stops(monkeypatch, capsys):
@@ -57,6 +75,110 @@ def test_docker_smoke_runs_container_checks_health_deps_and_stops(monkeypatch, c
     assert "runtime dependency check ok" in output
     assert "runtime source tree ok" in output
     assert "passed" in output
+
+
+def test_deployed_smoke_checks_readiness_and_win_models(monkeypatch, capsys):
+    requested_urls = []
+
+    def fake_urlopen(request, **_kwargs):
+        requested_urls.append(request.full_url)
+        if request.full_url.endswith("/api/health"):
+            return JsonResponse({"status": "ok"})
+        if request.full_url.endswith("/api/readiness"):
+            return JsonResponse({"ready": True, "checks": {"starter_model": {"ok": True}}})
+        if request.full_url.endswith("/api/predict/models?model_type=win"):
+            return JsonResponse({"models": [{"name": "ag-20260304_110750-win-extreme"}]})
+        raise AssertionError(f"unexpected URL: {request.full_url}")
+
+    monkeypatch.setattr(docker_smoke, "urlopen", fake_urlopen)
+
+    docker_smoke.check_deployed_readiness("http://127.0.0.1:8001", model_type="win", timeout_seconds=5)
+
+    assert requested_urls == [
+        "http://127.0.0.1:8001/api/health",
+        "http://127.0.0.1:8001/api/readiness",
+        "http://127.0.0.1:8001/api/predict/models?model_type=win",
+    ]
+    output = capsys.readouterr().out
+    assert "deployed health ok" in output
+    assert "deployed readiness ok" in output
+    assert "deployed win models ok: ag-20260304_110750-win-extreme" in output
+
+
+def test_deployed_smoke_reports_failed_readiness_checks(monkeypatch):
+    def fake_urlopen(request, **_kwargs):
+        if request.full_url.endswith("/api/health"):
+            return JsonResponse({"status": "ok"})
+        if request.full_url.endswith("/api/readiness"):
+            payload = {
+                "detail": {
+                    "ready": False,
+                    "checks": {
+                        "prediction_data_csv": {
+                            "ok": False,
+                            "path": "/app/data/prediction_data.csv",
+                            "rows": None,
+                            "missing_columns": ["fighter_name"],
+                        },
+                        "starter_model": {
+                            "ok": False,
+                            "expected": "ag-20260304_110750-win-extreme",
+                            "models": [],
+                        },
+                    },
+                }
+            }
+            body = io.BytesIO(json.dumps(payload).encode("utf-8"))
+            raise urllib.error.HTTPError(request.full_url, 503, "Service Unavailable", hdrs=None, fp=body)
+        raise AssertionError(f"unexpected URL: {request.full_url}")
+
+    monkeypatch.setattr(docker_smoke, "urlopen", fake_urlopen)
+
+    with pytest.raises(docker_smoke.SmokeError) as exc:
+        docker_smoke.check_deployed_readiness("http://127.0.0.1:8001", timeout_seconds=5)
+
+    message = str(exc.value)
+    assert "Deployed readiness check failed" in message
+    assert "prediction_data_csv" in message
+    assert "missing columns: fighter_name" in message
+    assert "starter_model" in message
+    assert "expected ag-20260304_110750-win-extreme; discovered none" in message
+
+
+def test_deployed_smoke_reports_empty_win_models(monkeypatch):
+    def fake_urlopen(request, **_kwargs):
+        if request.full_url.endswith("/api/health"):
+            return JsonResponse({"status": "ok"})
+        if request.full_url.endswith("/api/readiness"):
+            return JsonResponse({"ready": True, "checks": {"starter_model": {"ok": True}}})
+        if request.full_url.endswith("/api/predict/models?model_type=win"):
+            return JsonResponse({"models": []})
+        raise AssertionError(f"unexpected URL: {request.full_url}")
+
+    monkeypatch.setattr(docker_smoke, "urlopen", fake_urlopen)
+
+    with pytest.raises(docker_smoke.SmokeError, match="No win models found"):
+        docker_smoke.check_deployed_readiness("http://127.0.0.1:8001", model_type="win", timeout_seconds=5)
+
+
+def test_docker_smoke_cli_can_check_deployed_url(monkeypatch):
+    captured = {}
+
+    def fake_check(base_url, model_type, timeout_seconds):
+        captured["base_url"] = base_url
+        captured["model_type"] = model_type
+        captured["timeout_seconds"] = timeout_seconds
+
+    monkeypatch.setattr(docker_smoke, "check_deployed_readiness", fake_check)
+
+    exit_code = docker_smoke.main(["--deployed-url", "http://localhost:8001", "--model-type", "decision", "--timeout", "12"])
+
+    assert exit_code == 0
+    assert captured == {
+        "base_url": "http://localhost:8001",
+        "model_type": "decision",
+        "timeout_seconds": 12,
+    }
 
 
 def test_docker_smoke_uses_configured_timeout_for_first_container_start(monkeypatch):

--- a/tests/test_web/test_services.py
+++ b/tests/test_web/test_services.py
@@ -95,7 +95,23 @@ def test_get_analytics_status_reports_llm_configuration_without_secrets(monkeypa
 
 
 def test_get_analytics_status_reports_sql_only_mode_when_unconfigured(monkeypatch):
-    for key in ("LLM_PROVIDER", "LLM_MODEL", "LLM_API_KEY", "OPENAI_API_KEY", "LLM_BASE_URL"):
+    for key in (
+        "LLM_PROVIDER",
+        "LLM_MODEL",
+        "LLM_API_KEY",
+        "LLM_BASE_URL",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "XAI_API_KEY",
+        "GROK_API_KEY",
+        "OPENROUTER_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "MISTRAL_API_KEY",
+        "TOGETHER_API_KEY",
+        "PERPLEXITY_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
 
     status = get_analytics_status()
@@ -183,6 +199,36 @@ def test_get_readiness_status_requires_seed_data_model_csvs_model_and_databases(
         ("postgresql://postgres@localhost:5432/mma-ai", ["features.fight_mapping"]),
         ("postgresql://postgres@localhost:5432/odds", ["bestfightodds.bfo"]),
     ]
+
+
+def test_get_readiness_status_does_not_full_scan_large_csvs(monkeypatch, tmp_path):
+    raw_dir = tmp_path / "raw"
+    data_dir = tmp_path / "data"
+    models_dir = tmp_path / "AutogluonModels"
+    monkeypatch.setenv("MMA_AI_UFCSTATS_DIR", str(raw_dir))
+    monkeypatch.setenv("MMA_AI_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("MMA_AI_MODELS_DIR", str(models_dir))
+
+    write_csv(raw_dir / "competitions.csv", [{"event_url": "event-1"}, {"event_url": "event-2"}])
+    write_csv(raw_dir / "individuals.csv", [{"url": "fighter-1"}, {"url": "fighter-2"}])
+    write_csv(data_dir / "prediction_data.csv", [{"fighter_name": "fighter one"}, {"fighter_name": "fighter two"}])
+    write_csv(data_dir / "training_data.csv", [{"fighter1_name": "fighter one", "y_true": 1}])
+    write_csv(data_dir / "training_data_dec.csv", [{"fighter1_name": "fighter one", "y_true": 0}])
+    starter_model = models_dir / "ag-20260304_110750-win-extreme"
+    starter_model.mkdir(parents=True)
+    (starter_model / "feats.txt").write_text("feature\n", encoding="utf-8")
+    (starter_model / "predictor.pkl").write_text("starter", encoding="utf-8")
+    monkeypatch.setattr("libs.web.services._database_ready", lambda url, required_tables=None: {"ok": True, "url": url})
+
+    def fail_full_count(_path):
+        raise AssertionError("readiness should not full-scan CSV rows")
+
+    monkeypatch.setattr("libs.web.services._count_csv_rows", fail_full_count)
+
+    readiness = get_readiness_status()
+
+    assert readiness["ready"] is True
+    assert readiness["checks"]["prediction_data_csv"]["rows"] == 1
 
 
 def test_get_readiness_status_reports_missing_prerequisites(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Adds a deployed-stack mode to `mma-docker-smoke` so a running dashboard can be checked for the same setup conditions that gate prediction: `/api/health`, `/api/readiness`, and discoverable `win` models.

Also makes readiness fast for large restored CSVs by sampling for a data row instead of full-scanning hundreds of MB of CSV data, while keeping full row counts on the Data status path.

## Why

The Docker healthcheck only proved the app was alive. A deployed stack could still show `Setup incomplete` and `No win models found` when finalized CSVs or the starter model were missing. This gives us a deploy-time check that fails on those exact conditions with actionable diagnostics.

## Validation

- `uv run pytest tests/test_web tests/test_docker_smoke.py -q` -> 194 passed
- `uv run mma-docker-smoke --deployed-url http://127.0.0.1:8001 --timeout 30` -> deployed health/readiness/win model checks passed
- Verified the running Compose stack reports `/api/readiness` as `ready: true`
