### PR TITLE
[codex] Fix analytics ask button feedback

### DIFF
--- a/libs/web/llm.py
+++ b/libs/web/llm.py
@@ -245,24 +245,98 @@ def _generate_openai_compatible(prompt: dict[str, Any] | str, config: LlmConfig,
     if json_mode:
         payload["response_format"] = {"type": "json_object"}
 
-    response = requests.post(
-        f"{base_url}/chat/completions",
-        headers=headers,
-        json=payload,
-        timeout=config.timeout_seconds,
-    )
+    response = _post_openai_compatible(base_url, headers, payload, config)
     if getattr(response, "status_code", 0) >= 400 and json_mode and config.provider in {"local", "custom"}:
         # Some local OpenAI-compatible servers do not implement response_format.
         payload.pop("response_format", None)
-        response = requests.post(
+        response = _post_openai_compatible(base_url, headers, payload, config)
+    _raise_for_llm_status(response, config.provider)
+    data = _response_json(response, config.provider)
+    provider_error = _llm_error_message(data)
+    if provider_error:
+        raise RuntimeError(f"LLM {config.provider} returned an error: {provider_error}")
+    try:
+        content = data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as exc:
+        summary = _llm_response_summary(data)
+        detail = f": {summary}" if summary else ""
+        raise RuntimeError(f"LLM {config.provider} response did not include chat completion content{detail}") from exc
+    if not isinstance(content, str):
+        raise RuntimeError(f"LLM {config.provider} response content was not text.")
+    return content
+
+
+def _post_openai_compatible(
+    base_url: str,
+    headers: dict[str, str],
+    payload: dict[str, Any],
+    config: LlmConfig,
+) -> requests.Response:
+    try:
+        return requests.post(
             f"{base_url}/chat/completions",
             headers=headers,
             json=payload,
             timeout=config.timeout_seconds,
         )
-    response.raise_for_status()
-    data = response.json()
-    return data["choices"][0]["message"]["content"]
+    except requests.RequestException as exc:
+        raise RuntimeError(f"LLM {config.provider} request failed: {exc}") from exc
+
+
+def _raise_for_llm_status(response: requests.Response, provider: str) -> None:
+    try:
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        detail = _llm_error_message_from_response(response)
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(f"LLM {provider} request failed{suffix}") from exc
+
+
+def _response_json(response: requests.Response, provider: str) -> dict[str, Any]:
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise RuntimeError(f"LLM {provider} returned invalid JSON.") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(f"LLM {provider} returned an unexpected response shape.")
+    return data
+
+
+def _llm_error_message_from_response(response: requests.Response) -> str | None:
+    try:
+        return _llm_error_message(response.json())
+    except ValueError:
+        text = getattr(response, "text", "")
+        return _truncate_message(text) if text else None
+
+
+def _llm_error_message(data: Any) -> str | None:
+    if not isinstance(data, dict):
+        return None
+    error = data.get("error")
+    if isinstance(error, dict):
+        return _truncate_message(error.get("message") or error.get("code") or json.dumps(error, default=str))
+    if error:
+        return _truncate_message(str(error))
+    message = data.get("message")
+    if message:
+        return _truncate_message(str(message))
+    return None
+
+
+def _llm_response_summary(data: dict[str, Any]) -> str:
+    error = _llm_error_message(data)
+    if error:
+        return error
+    keys = ", ".join(sorted(str(key) for key in data.keys()))
+    return f"response keys: {keys}" if keys else "empty JSON object"
+
+
+def _truncate_message(value: str, limit: int = 500) -> str:
+    text = " ".join(str(value).split())
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 1]}..."
 
 
 def _generate_anthropic(prompt: dict[str, Any] | str, config: LlmConfig, *, json_mode: bool) -> str:

--- a/libs/web/static/app.js
+++ b/libs/web/static/app.js
@@ -15,9 +15,24 @@ async function api(path, options = {}) {
   });
   if (!response.ok) {
     const body = await response.json().catch(() => ({ detail: response.statusText }));
-    throw new Error(body.detail || response.statusText);
+    throw new Error(apiErrorMessage(body.detail) || apiErrorMessage(body.error) || response.statusText);
   }
   return response.json();
+}
+
+function apiErrorMessage(detail) {
+  if (!detail) return "";
+  if (typeof detail === "string") return detail;
+  if (Array.isArray(detail)) {
+    return detail
+      .map((item) => apiErrorMessage(item))
+      .filter(Boolean)
+      .join("; ");
+  }
+  if (typeof detail === "object") {
+    return detail.msg || detail.message || detail.error || JSON.stringify(detail);
+  }
+  return String(detail);
 }
 
 function renderJson(target, value) {
@@ -124,6 +139,19 @@ function renderAnalyticsReport(result) {
 function renderAnalyticsError(message) {
   qs("#analytics-output").innerHTML = `<div class="analytics-error">${escapeHtml(message)}</div>`;
   renderPlotlyCharts("#analytics-chart", []);
+}
+
+function renderAnalyticsLoading() {
+  qs("#analytics-output").innerHTML = `<div class="muted">Asking analytics...</div>`;
+  renderPlotlyCharts("#analytics-chart", []);
+}
+
+function setAnalyticsBusy(isBusy) {
+  const button = qs("#run-analytics");
+  if (!button) return;
+  button.disabled = Boolean(isBusy);
+  const label = button.querySelector("span");
+  if (label) label.textContent = isBusy ? "Asking" : "Ask";
 }
 
 function escapeHtml(value) {
@@ -702,11 +730,18 @@ function wireData() {
     }
   });
   qs("#run-analytics").addEventListener("click", async () => {
+    const question = qs("#analytics-question").value.trim();
+    if (question.length < 3) {
+      renderAnalyticsError("Enter an analytics question with at least 3 characters.");
+      return;
+    }
+    setAnalyticsBusy(true);
+    renderAnalyticsLoading();
     try {
       const result = await api("/api/data/analytics", {
         method: "POST",
         body: JSON.stringify({
-          question: qs("#analytics-question").value,
+          question,
           sql: qs("#analytics-sql").value || null,
           max_rows: Number(qs("#analytics-max-rows").value || 100),
         }),
@@ -714,6 +749,8 @@ function wireData() {
       renderAnalyticsReport(result);
     } catch (error) {
       renderAnalyticsError(error.message);
+    } finally {
+      setAnalyticsBusy(false);
     }
   });
 }

--- a/libs/web/static/index.html
+++ b/libs/web/static/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>MMA AI</title>
-    <link rel="stylesheet" href="/static/styles.css?v=analytics-python-20260601" />
+    <link rel="stylesheet" href="/static/styles.css?v=analytics-ask-20260605" />
     <script src="/vendor/plotly.min.js"></script>
-    <script src="/static/icons.js?v=analytics-python-20260601"></script>
+    <script src="/static/icons.js?v=analytics-ask-20260605"></script>
   </head>
   <body>
     <header class="topbar">
@@ -164,6 +164,6 @@
     </main>
 
     <footer id="job-strip"></footer>
-    <script src="/static/app.js?v=analytics-python-20260601"></script>
+    <script src="/static/app.js?v=analytics-ask-20260605"></script>
   </body>
 </html>

--- a/tests/test_web/test_llm.py
+++ b/tests/test_web/test_llm.py
@@ -169,3 +169,48 @@ def test_local_openai_compatible_json_mode_retries_without_response_format(monke
     assert calls[0]["json"]["response_format"] == {"type": "json_object"}
     assert "response_format" not in calls[1]["json"]
     assert "Authorization" not in calls[1]["headers"]
+
+
+def test_openai_compatible_provider_error_body_raises_runtime_error(monkeypatch):
+    clear_llm_env(monkeypatch)
+    monkeypatch.setenv("LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("LLM_MODEL", "unit-test-model")
+    monkeypatch.setenv("LLM_API_KEY", "unit-test-key")
+
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"error": {"message": "No endpoints found for unit-test-model"}}
+
+    def fake_post(url, headers, json, timeout):
+        return FakeResponse()
+
+    monkeypatch.setattr("libs.web.llm.requests.post", fake_post)
+
+    with pytest.raises(RuntimeError, match="No endpoints found for unit-test-model"):
+        llm_generate_text({"task": "json please"}, json_mode=True)
+
+
+def test_openai_compatible_missing_choices_raises_runtime_error(monkeypatch):
+    clear_llm_env(monkeypatch)
+    monkeypatch.setenv("LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("LLM_MODEL", "unit-test-model")
+    monkeypatch.setenv("LLM_API_KEY", "unit-test-key")
+
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"id": "chatcmpl-test", "object": "chat.completion"}
+
+    monkeypatch.setattr("libs.web.llm.requests.post", lambda *args, **kwargs: FakeResponse())
+
+    with pytest.raises(RuntimeError, match="response did not include chat completion content"):
+        llm_generate_text({"task": "json please"}, json_mode=True)

--- a/tests/test_web/test_static_ui.py
+++ b/tests/test_web/test_static_ui.py
@@ -11,8 +11,8 @@ def test_prediction_card_renderer_exposes_value_and_market_context():
 
     assert 'src="/vendor/plotly.min.js"' in html
     assert 'src="/static/icons.js' in html
-    assert 'src="/static/app.js?v=analytics-python-20260601"' in html
-    assert 'href="/static/styles.css?v=analytics-python-20260601"' in html
+    assert 'src="/static/app.js?v=analytics-ask-20260605"' in html
+    assert 'href="/static/styles.css?v=analytics-ask-20260605"' in html
     assert "cdn.plot.ly" not in html
     assert "unpkg.com" not in html
     assert "Pick" in app_js
@@ -58,6 +58,7 @@ def test_local_icon_bundle_covers_dashboard_icons():
 def test_primary_workflow_buttons_render_api_errors_in_place():
     app_js = (STATIC_DIR / "app.js").read_text(encoding="utf-8")
 
+    assert "function apiErrorMessage(detail)" in app_js
     assert app_js.count("catch (error)") >= 7
     assert 'renderJson("#data-output", error.message)' in app_js
     assert 'renderJson("#events-output", error.message)' in app_js
@@ -258,6 +259,8 @@ def test_analytics_options_expose_bounded_row_limit():
     assert "Analytics agent system prompt copied." in app_js
     assert "max_rows: Number(qs(\"#analytics-max-rows\").value || 100)" in app_js
     assert "function renderAnalyticsReport(result)" in app_js
+    assert "function renderAnalyticsLoading()" in app_js
+    assert "function setAnalyticsBusy(isBusy)" in app_js
     assert "function renderPlotlyCharts(target, charts)" in app_js
     assert "normalizeAnalyticsCharts(result)" in app_js
     assert "function renderPlotlyChart(target, chart)" not in app_js
@@ -267,6 +270,10 @@ def test_analytics_options_expose_bounded_row_limit():
     assert "Plotly.purge(element)" in app_js
     assert "renderAnalyticsReport(result)" in app_js
     assert "renderAnalyticsError(error.message)" in app_js
+    assert "Enter an analytics question with at least 3 characters." in app_js
+    assert "setAnalyticsBusy(true)" in app_js
+    assert "renderAnalyticsLoading()" in app_js
+    assert "setAnalyticsBusy(false)" in app_js
     assert 'id="analytics-output" class="result analytics-report"' in html
     assert 'id="analytics-chart" class="chart analytics-chart-grid"' in html
     assert ".analytics-status.ready" in styles


### PR DESCRIPTION
## Summary
- Show immediate loading and validation feedback when the Data-tab Analytics Ask button is clicked.
- Parse structured FastAPI/API errors in the dashboard instead of rendering vague failures.
- Convert malformed OpenAI-compatible LLM responses into dashboard-safe runtime errors.
- Bump the static asset query string so browsers load the fixed JavaScript.

## Root Cause
The Ask button had no in-flight state, so slow analytics/LLM calls appeared inert. Separately, malformed provider responses without `choices` raised an unhandled `KeyError`, producing a generic 500.

## Validation
- `uv run pytest tests\test_web\test_llm.py tests\test_web\test_static_ui.py tests\test_web\test_api.py -q`
- `MMA_AI_RUN_BROWSER_E2E=1 uv run pytest tests\e2e\test_data_tab_analytics_prompt.py::test_data_tab_browser_renders_llm_analytics_report_with_charts -q`
- Local in-app browser check at `http://127.0.0.1:8766` confirmed the cache-busted script and empty Ask validation feedback.