### PR TITLE
[codex] Document analytics schema guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ Training remains a CLI workflow.
 - `libs/modeling`: training, walk-forward utilities, evaluation, calibration,
   profit reporting, and portable artifacts.
 - `scripts`: CLI adapters and release/dev utilities.
+- `docs/ANALYTICS_SCHEMA.md`: plain-English analytics schema reference for
+  feature meanings, leakage status, odds units, and query patterns.
 - `data/raw/ufcstats`: tracked seed `competitions.csv` and `individuals.csv`.
 - `docker/postgres-init/01-create-odds.sql`: creates the auxiliary `odds`
   database used by `ODDS_DATABASE_URL`.
@@ -101,8 +103,10 @@ Predict tab:
 - Load upcoming events from Wikipedia into an event-name dropdown.
 - Predict events and manual fighter matchups through the same `predict.py` and
   `InferenceDataBuilder` path.
-- Odds are enabled by default but are not model inputs. They calculate market
-  probability, expected value, and pick edge only.
+- Prediction-time live/manual odds are enabled by default but are used for
+  market probability, expected value, and pick edge reporting. Historical odds
+  columns may exist in generated CSVs and model artifacts; inspect `feats.txt`
+  before claiming whether a specific model used odds.
 - Manual matchup odds controls are not exposed in the dashboard.
 - The advanced Flaresolverr proxy toggle is only for BestFightOdds blocking
   normal odds scraping.
@@ -166,6 +170,11 @@ Feature-family tables are split from `fight_stats_derived`. Common families are
 `age`, `reach`, `ape`, `ufcage`, `days_since_last_fight`, `sig_str`, `strikes`,
 `td`, `sub`, `ctrl`, `head`, `body`, `leg`, `distance`, `clinch`, `ground`,
 `ko`, `decision`, `win`, `time_sec`, and `odds`.
+
+For complex analytics, consult `docs/ANALYTICS_SCHEMA.md` before writing queries.
+It documents plain-English feature meanings, known-before-fight vs post-fight
+status, and the difference between historical decimal odds in `features.odds`
+and live/manual American odds used during prediction.
 
 Feature suffixes:
 
@@ -285,5 +294,6 @@ Add tests with every behavior change.
 - If you change public setup, Docker, dashboard assets, or artifact restore
   behavior, update `README.md`, `docs/RELEASE_READINESS.md`, and
   `docs/HUGGINGFACE_DATASET.md` as needed.
-- If you change feature semantics, update `README.md` and tests so analytics
-  agents can craft correct queries.
+- If you change feature semantics, update `README.md`,
+  `docs/ANALYTICS_SCHEMA.md`, and tests so analytics agents can craft correct
+  queries.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,13 @@ and Predict dashboard. Training remains a CLI workflow, not a dashboard tab.
   update.
 - Predict: select a model, automatically load upcoming UFC events from
   Wikipedia into an event-name dropdown, predict the selected event, and run
-  manual fighter matchups through the same inference path. Odds are enabled by
-  default but only calculate EV, market probability, and pick edge; they are not
-  model inputs. Manual matchup per-fighter odds controls are not exposed in the
-  dashboard. The advanced Flaresolverr proxy toggle is only for BestFightOdds
-  blocking normal odds scraping.
+  manual fighter matchups through the same inference path. Prediction-time
+  live/manual odds are enabled by default but only calculate EV, market
+  probability, and pick edge reporting. Historical odds columns can exist in
+  generated CSVs and model artifacts; inspect `feats.txt` before claiming
+  whether a specific model used odds. Manual matchup per-fighter odds controls
+  are not exposed in the dashboard. The advanced Flaresolverr proxy toggle is
+  only for BestFightOdds blocking normal odds scraping.
 
 LLM-assisted analytics use `LLM_PROVIDER`, `LLM_MODEL`, `LLM_API_KEY`, and
 optional `LLM_BASE_URL` first. The setup scripts can configure OpenAI,
@@ -118,6 +120,11 @@ Feature suffixes:
 - `_opp_*`: opponent features.
 - `_adjperf`, `_dec_adjperf`: opponent-adjusted performance.
 - `_diff`: fighter1 minus fighter2 for model input.
+
+For deeper analytics, consult `docs/ANALYTICS_SCHEMA.md` before writing
+nontrivial queries. It documents feature-family meanings, leakage status,
+`_adjperf` interpretation, and the difference between historical decimal odds
+in `features.odds` and live/manual American odds used during prediction.
 
 ## Training Defaults
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ users.
 5. [Feature Engineering Pipeline](#feature-engineering-pipeline)
 6. [Layer Reference](#layer-reference)
 7. [Query Patterns](#query-patterns)
-8. [Manual Development Setup](#manual-development-setup)
+8. [Analytics Schema Reference](#analytics-schema-reference)
+9. [Manual Development Setup](#manual-development-setup)
 
 ## Quick Start
 
@@ -189,13 +190,14 @@ uv run mma-release-audit
   the dashboard is currently in SQL-only analytics mode.
 - Predict: choose a model, automatically load upcoming UFC events from
   Wikipedia into an event-name dropdown, predict a selected event, or run a
-  manual fighter-vs-fighter matchup. Odds are enabled by default but are used
-  only for market probability, expected value, and pick edge, not as model
-  inputs. Event prediction accepts manual fighter odds in the dashboard so web
-  jobs never need to block on terminal prompts. Manual matchup prediction
-  defaults the fight date to today and does not expose per-fighter odds
-  controls. Use the advanced Flaresolverr proxy toggle only when BestFightOdds
-  is blocking normal odds scraping.
+  manual fighter-vs-fighter matchup. Prediction-time live/manual odds are
+  enabled by default for market probability, expected value, and pick-edge
+  reporting, rather than being passed into the predictor. Event prediction
+  accepts manual fighter odds in the dashboard so web jobs never need to block
+  on terminal prompts. Manual matchup prediction defaults the fight date to
+  today and does not expose per-fighter odds controls. Use the advanced
+  Flaresolverr proxy toggle only when BestFightOdds is blocking normal odds
+  scraping.
 
 Each long-running Data or Predict job streams stdout/stderr into a debug log
 under `data/logs/jobs` and exposes it through the dashboard and
@@ -242,8 +244,10 @@ fork a separate feature or prediction implementation.
 
 ## Project Files
 
-- `AGENTS.md` and `CLAUDE.md`: agent guidance for safe analytics, training,
-  prediction, feature semantics, and test expectations.
+- `AGENTS.md` and `CLAUDE.md`: compact agent guidance for safe analytics,
+  training, prediction, feature semantics, and test expectations.
+- `docs/ANALYTICS_SCHEMA.md`: deeper plain-English analytics schema reference
+  for feature meanings, odds units, leakage status, and query patterns.
 - `Dockerfile` and `docker-compose.yml`: public release runtime with Postgres
   and the FastAPI dashboard.
 - `libs/web`: FastAPI app, background jobs, web service adapters, analytics,
@@ -899,17 +903,19 @@ UFCStats. It has the same `(fight_id, fighter_id, event_id)` grain.
 
 Important columns:
 
-- `opening_odds`, `closing_odds`: American odds.
-- `ip_opening_odds`, `ip_closing_odds`: implied probabilities from American
-  odds.
+- `opening_odds`, `closing_odds`: decimal odds from BestFightOdds.
+- `ip_opening_odds`, `ip_closing_odds`: implied probabilities from decimal
+  odds, computed as `1 / decimal_odds`.
 - `vigless_ip_opening_odds`, `vigless_ip_closing_odds`: no-vig normalized
   implied probabilities across the two fighters.
 - `sevenday_opening_odds`, `sevenday_ip_opening_odds`,
   `sevenday_vigless_ip_opening_odds`: odds closest to seven days before close.
 
-Odds are enabled by default in prediction jobs, but they are not model inputs in
-the dashboard path. They are used for market probability, expected value, and
-pick-edge reporting.
+Prediction-time live or manual odds use American odds in the UI/CLI and are used
+for market probability, expected value, and pick-edge reporting. Historical odds
+columns can still appear in generated CSVs, profit analysis, and model feature
+lists depending on the artifact. Inspect a model's `feats.txt` before claiming
+whether odds were or were not model inputs.
 
 ## Reading Feature Names
 
@@ -980,8 +986,8 @@ The main finalized outputs are:
 - `data/training_data_dec.csv`: decision/no-decision model training data.
 
 Static features are not shifted because they are known pre-fight: `age`,
-`days_since_last_fight`, `reach`, `height`, `ufcage`, `odds`, and
-`weightclass_encoded`.
+`days_since_last_fight`, `reach`, `height`, `ufcage`, historical odds fields
+when included, and `weightclass_encoded`.
 
 A valid starter model directory such as `ag-20260304_110750-win-extreme`
 usually includes `feats.txt`. Single models also need `scaler.pkl`; walk-forward
@@ -1078,6 +1084,14 @@ For Postgres analytics, prefer sources in this order:
 2. Feature-specific tables for understanding a feature family.
 3. `features.fight_stats_derived` for row-level engineered features.
 4. `features.fight_stats_fe` only when investigating raw scrape quality.
+
+## Analytics Schema Reference
+
+For deeper analytics work, see `docs/ANALYTICS_SCHEMA.md`. It documents the
+fighter-fight grain, table families, feature suffixes, plain-English
+interpretations such as `_adjperf`, historical-vs-predictive leakage rules,
+`ODDS_DATABASE_URL` / `bestfightodds.bfo`, and the decimal-vs-American odds
+boundary.
 
 ## Analytics Safety
 

--- a/docs/ANALYTICS_SCHEMA.md
+++ b/docs/ANALYTICS_SCHEMA.md
@@ -1,0 +1,255 @@
+# Analytics Schema Reference
+
+Use this document when writing analytics against MMA AI data. It is the
+plain-English companion to the feature-store code and the live database schema.
+When there is any mismatch, inspect the current database with
+`information_schema` before making a claim.
+
+## Core Grain
+
+Most `features` tables use one central grain:
+
+```text
+one row = one fighter in one completed fight
+primary key = fight_id, fighter_id, event_id
+```
+
+`features.fight_mapping` is one row per fight and stores both fighter IDs.
+`features.event_mapping` gives the fight date. `features.fighter_mapping` gives
+names and profile fields. For fighter-vs-fighter comparisons, join a feature
+table twice: once for `fighter1_id` and once for `fighter2_id`.
+
+## Source Priority
+
+Prefer analytics sources in this order:
+
+1. Finalized `model_data` tables or CSVs for model-facing questions.
+2. Feature-family tables such as `features.sig_str`, `features.td`,
+   `features.ctrl`, `features.odds`, or `features.style`.
+3. `features.fight_stats_derived` for row-level engineered features.
+4. `features.fight_stats_fe` only for raw scrape or calculator-quality checks.
+
+For predictive analytics, avoid leakage. Feature-family tables are post-fight
+artifacts for completed fights: `_avg`, `_dec_avg`, `_total`, and `_mad`
+include the current completed row. Use `training_data.csv`, inference-builder
+outputs, `_prev` columns, or an explicit past-only query when answering a
+pre-fight question.
+
+## Table Families
+
+| Table family | Plain-English meaning | Analytics notes |
+| --- | --- | --- |
+| `age` | Fighter age at the event date | Known before the fight. |
+| `days_since_last_fight` | Layoff/rest before the fight | Known before the fight. |
+| `reach`, `height` | Reach and height in inches | Missing values may be imputed by weight class. |
+| `ape` | Reach divided by height | Ratio, not reach-minus-height. |
+| `ufcage` | Years since first UFCStats fight | Known before the fight. |
+| `sig_str` | Significant striking volume, accuracy, defense, rates, shares | Smoothed values after derived staging. |
+| `strikes` | Total strike volume, accuracy, defense, rates, shares | Broader than significant strikes. |
+| `head`, `body`, `leg` | Significant strikes by target | Use for targeting and defensive accuracy questions. |
+| `distance`, `clinch`, `ground` | Significant strikes by position/range | Use for range mix and range-specific efficiency. |
+| `td` | Takedowns landed/attempted, accuracy, defense, pace | `td_def` is opponent takedown accuracy against the fighter. |
+| `ctrl` | Control time in seconds and rates/shares | `ctrl_per_min` is control seconds per fight minute. |
+| `sub` | Submission attempts and submission-win indicators | `sub_land` means completed submission win when present. |
+| `rev` | Reversals | Often sparse; report sample size. |
+| `kd` | Knockdowns | Often sparse; prefer rates or adjusted summaries for broad claims. |
+| `ko`, `decision`, `win` | Outcome indicators and finish-derived features | Post-fight outcomes; do not use as pre-fight evidence unless shifted. |
+| `time_sec` | Fight duration | Post-fight outcome-like duration. |
+| `odds` | Historical BestFightOdds-derived market prices and probabilities | See odds section below; missing odds means missing market data. |
+| `style` | Composite style metrics from lower-level features | Good for exploratory style summaries; inspect definitions before causal claims. |
+
+Discover the tables and columns that exist in a restored database:
+
+```sql
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'features'
+  AND table_type = 'BASE TABLE'
+ORDER BY table_name;
+```
+
+```sql
+SELECT column_name, data_type
+FROM information_schema.columns
+WHERE table_schema = 'features'
+  AND table_name = 'sig_str'
+ORDER BY ordinal_position;
+```
+
+## Suffix Semantics
+
+| Suffix | Plain-English meaning |
+| --- | --- |
+| `_rd1` | First-round value. |
+| `_smooth` | Temporary Bayesian-smoothed column before it is renamed to the base name. |
+| `_raw` | Temporary observed value kept briefly for accuracy calculations. |
+| `_total` | Fighter cumulative total through the completed row. |
+| `_acc` | Landed divided by attempted, with Bayesian smoothing. |
+| `_def` | Opponent accuracy against this fighter in the same fight. Lower is better defense. |
+| `_per_min` | Rate per fight minute, using `time_sec / 60`. |
+| `_ratio` | Fighter share of fighter-plus-opponent value in the same fight. |
+| `_pressure` | First-round share of total output for that stat. |
+| `_per_` | Domain-specific conversion ratio, such as `td_land_per_ctrl`. |
+| `_opp` | The opponent's realized same-fight value copied onto this fighter row. |
+| `_wc_mean` | Weight-class prior mean in support tables. |
+| `_wc_mad` | Weight-class prior median absolute deviation in support tables. |
+| `_minimum_mad` | MAD floor used to keep adjusted performance stable. |
+| `_avg` | Fighter rolling average through the completed row. |
+| `_dec_avg` | Fighter time-decayed rolling average through the completed row. |
+| `_mad` | Fighter rolling median absolute deviation. |
+| `_adjperf` | Opponent-adjusted performance score. |
+| `_dec_adjperf` | Opponent-adjusted performance score using time-decayed opponent history. |
+| `_prev` | Previous-fight shifted feature in cleaned training data. |
+| `_diff` | Fighter1 value minus fighter2 value in finalized fight-row data. |
+
+## Adjusted Performance
+
+`_adjperf` asks:
+
+```text
+How much better or worse was this fighter's observed stat than what this
+opponent historically allows, after shrinking sparse opponent history toward
+weight-class priors?
+```
+
+For example, `sig_str_land_per_min_adjperf` compares the fighter's significant
+strikes landed per minute in this fight to what previous opponents usually
+landed per minute against today's opponent. Sparse opponent histories are
+shrunk toward weight-class baselines.
+
+The score is z-score-like and clipped. Positive values mean the fighter exceeded
+expectation against that opponent. Negative values mean the fighter
+underperformed relative to expectation. `_dec_adjperf` uses the same idea but
+weights the opponent's historical allowance by recency.
+
+Read long names left to right:
+
+```text
+distance_acc_dec_adjperf_dec_avg
+```
+
+means distance-striking accuracy, compared against a time-decayed
+opponent-allowed expectation, converted into adjusted performance, then averaged
+over the fighter's own history with time decay.
+
+## Odds Databases
+
+There are two odds-related storage layers.
+
+`ODDS_DATABASE_URL` points to the auxiliary odds database. Its important table is
+`bestfightodds.bfo`:
+
+| Column | Meaning |
+| --- | --- |
+| `id` | Surrogate row ID. |
+| `fighter` | BestFightOdds fighter name. |
+| `fighter_url` | BestFightOdds fighter URL when available. |
+| `opponent` | BestFightOdds opponent name. |
+| `timestamp` | Timestamp for the price point. |
+| `odds` | Decimal odds from BestFightOdds, not American odds. |
+
+Rows are unique by `(fighter, opponent, timestamp)`. This table is the imported
+or scraped market-data source. It is not joined directly for most analytics.
+
+`features.odds` lives in the main MMA database and is generated from
+`bestfightodds.bfo`. It uses the normal fighter-fight grain:
+
+| Column | Meaning |
+| --- | --- |
+| `opening_odds` | First decimal odds point found for the matched fighter/opponent group. |
+| `closing_odds` | Last decimal odds point found for the matched group. |
+| `sevenday_opening_odds` | Decimal odds closest to seven days before close, falling back when needed. |
+| `ip_opening_odds` | Implied probability from `opening_odds`, computed as `1 / decimal_odds`. |
+| `ip_closing_odds` | Implied probability from `closing_odds`. |
+| `sevenday_ip_opening_odds` | Implied probability from `sevenday_opening_odds`. |
+| `vigless_ip_opening_odds` | Opening implied probability normalized across both fighters. |
+| `vigless_ip_closing_odds` | Closing implied probability normalized across both fighters. |
+| `sevenday_vigless_ip_opening_odds` | Seven-day implied probability normalized across both fighters. |
+
+Odds matching is name-based and date-tolerant. The calculator groups BFO rows by
+fighter, opponent, and event month, then matches to UFCStats fights by lower-case
+fighter names near the event date. Rematches, missing opponent rows, and name
+aliases are the main failure modes. Always report odds coverage and null rates.
+
+Prediction-time live/manual odds use American odds in the UI/CLI, then convert
+to implied probabilities or vig-free American odds for reporting. Do not confuse
+those live American odds with historical `features.odds` decimal columns.
+
+Dashboard live odds are used for market probability, AI odds, expected value,
+and pick-edge reporting. Historical odds columns can still appear in
+`prediction_data.csv`, `training_data.csv`, profit reports, and model feature
+lists depending on the artifact. Inspect a model's `feats.txt` before claiming
+whether odds were or were not model inputs.
+
+## Model Outputs
+
+`data/prediction_data.csv` is a wide fighter-row feature matrix used by the
+inference builder. Despite the name, it is not only predictions.
+
+`data/training_data.csv` and `data/training_data_dec.csv` are finalized
+fight-row model data:
+
+1. Dynamic fighter stats are shifted to the previous fight and receive `_prev`.
+2. Fighter1 and fighter2 rows are joined into one fight row.
+3. `_diff` columns are fighter1 minus fighter2.
+4. Static/pre-fight features such as `age`, `days_since_last_fight`, `reach`,
+   `height`, `ufcage`, historical odds fields, and `weightclass_encoded` are not
+   shifted.
+
+For model explanations, use the exact columns in the model artifact's
+`feats.txt`. For descriptive fight-history analytics, feature-family tables are
+usually easier to read.
+
+## Query Patterns
+
+Join a feature table to names and dates:
+
+```sql
+SELECT
+  em.event_date,
+  fmap.fighter_name,
+  s.sig_str_land_per_min_dec_avg
+FROM features.sig_str s
+JOIN features.event_mapping em ON em.event_id = s.event_id
+JOIN features.fighter_mapping fmap ON fmap.fighter_id = s.fighter_id
+ORDER BY em.event_date DESC
+LIMIT 50;
+```
+
+Compare both fighters in a fight:
+
+```sql
+SELECT
+  em.event_date,
+  f1.fighter_name AS fighter1_name,
+  f2.fighter_name AS fighter2_name,
+  s1.sig_str_land_per_min_dec_avg AS f1_sig_str_pm,
+  s2.sig_str_land_per_min_dec_avg AS f2_sig_str_pm,
+  s1.sig_str_land_per_min_dec_avg - s2.sig_str_land_per_min_dec_avg AS diff
+FROM features.fight_mapping fm
+JOIN features.event_mapping em ON em.event_id = fm.event_id
+JOIN features.fighter_mapping f1 ON f1.fighter_id = fm.fighter1_id
+JOIN features.fighter_mapping f2 ON f2.fighter_id = fm.fighter2_id
+JOIN features.sig_str s1
+  ON s1.fight_id = fm.fight_id
+ AND s1.fighter_id = fm.fighter1_id
+JOIN features.sig_str s2
+  ON s2.fight_id = fm.fight_id
+ AND s2.fighter_id = fm.fighter2_id;
+```
+
+Check odds coverage:
+
+```sql
+SELECT
+  COUNT(*) AS fighter_rows,
+  COUNT(o.closing_odds) AS rows_with_closing_odds,
+  AVG(o.vigless_ip_closing_odds) AS avg_vigless_close_ip
+FROM features.fight_mapping fm
+JOIN features.event_mapping em ON em.event_id = fm.event_id
+LEFT JOIN features.odds o ON o.fight_id = fm.fight_id;
+```
+
+When a question depends on time ordering, add a CTE that restricts each
+fighter's history to rows before the fight date being analyzed. Do not rely on
+feature-family `_avg` or `_dec_avg` columns as pre-fight values.

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -62,10 +62,11 @@ badge.
 - Predict tab: list models, automatically load upcoming UFC events from
   Wikipedia into an event-name dropdown, predict a selected event, run manual
   fighter matchups, and show book odds, AI odds, positive EV status, and pick
-  edge in compact result cards. Odds are enabled by default but are not model
-  inputs; event prediction can ingest manual American odds through the
-  dashboard/API instead of waiting on terminal input. Manual matchup prediction
-  defaults the fight date to today and does not expose per-fighter odds controls.
+  edge in compact result cards. Prediction-time live/manual odds are enabled by
+  default but are used for reporting rather than passed into the predictor;
+  event prediction can ingest manual American odds through the dashboard/API
+  instead of waiting on terminal input. Manual matchup prediction defaults the
+  fight date to today and does not expose per-fighter odds controls.
   The advanced Flaresolverr proxy toggle is only for BestFightOdds blocking
   normal odds scraping.
 - Job logs: Data and Predict jobs stream and persist stdout, stderr,

--- a/libs/web/analytics_prompt.py
+++ b/libs/web/analytics_prompt.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-ANALYTICS_AGENT_SYSTEM_PROMPT_VERSION = "2026-06-01"
+ANALYTICS_AGENT_SYSTEM_PROMPT_VERSION = "2026-06-05"
 
 
 ANALYTICS_AGENT_SYSTEM_PROMPT = """
@@ -70,7 +70,7 @@ Feature families and plain-language meanings:
 - age: fighter age at the fight date.
 - reach: reach in inches when available.
 - height: height in inches when available.
-- ape: reach minus height.
+- ape: reach divided by height.
 - ufcage: years since the fighter's first UFC fight.
 - days_since_last_fight: rest or layoff entering the bout.
 - weightclass and weightclass_encoded: fight division metadata.
@@ -104,14 +104,16 @@ Important suffixes:
 - _per means a conversion metric, such as ko_per_sig_str_land or td_per_ctrl.
 - _pressure means first-round share relative to total.
 - _avg means historical simple average.
-- _dec_avg means time-decayed historical average. Treat it as already
-  past-only for historical rows.
+- _dec_avg means time-decayed historical average through the completed row in
+  feature-family tables. Treat it as post-fight unless you are using finalized
+  training/inference data or an explicit past-only query.
 - _mad means median absolute deviation.
 - _sdev means standard deviation.
 - _wc_mean means weight-class baseline mean.
 - _wc_mad means weight-class median absolute deviation.
 - _minimum_mad means floor used to avoid unstable adjusted-performance scores.
-- _opp means what opponents historically achieved against the fighter.
+- _opp means the opponent's realized same-fight value copied onto this fighter
+  row.
 - _adjperf means opponent-adjusted performance, usually a reliability-weighted
   z-score comparing observed performance to expected performance against that
   opponent.
@@ -125,11 +127,17 @@ Odds guidance:
   ip_opening_odds, ip_closing_odds, sevenday_ip_opening_odds,
   vigless_ip_opening_odds, vigless_ip_closing_odds, and
   sevenday_vigless_ip_opening_odds.
-- ip_* fields are implied probabilities from decimal odds.
+- opening_odds, closing_odds, and sevenday_opening_odds are decimal odds from
+  historical BestFightOdds data, not American odds.
+- ip_* fields are implied probabilities from decimal odds, computed as
+  1 / decimal_odds.
 - vigless_ip_* fields normalize the two sides of a fight to remove bookmaker
   overround.
-- Dashboard prediction odds are not model inputs. They are used to calculate
-  market probability, AI odds, expected value, and pick edge.
+- Dashboard live/manual prediction odds are American odds used to calculate
+  market probability, AI odds, expected value, and pick edge reporting.
+- Historical odds columns can appear in generated CSVs, profit analysis, and
+  model feature lists. Inspect a model's feats.txt before claiming whether that
+  model used odds.
 - For EV-style analytics, define edge as AI probability minus market implied
   probability when both fields exist.
 

--- a/libs/web/static/index.html
+++ b/libs/web/static/index.html
@@ -80,7 +80,7 @@
             <label class="span-two">Model <select id="predict-model"></select></label>
             <div class="checkbox-field">
               <label><input id="predict-odds" type="checkbox" /> Odds</label>
-              <p class="field-note">Odds are not a feature in the model; they solely exist to calculate the Expected Value of each prediction.</p>
+              <p class="field-note">These live prediction odds are not passed into the model; they solely exist to calculate the Expected Value of each prediction.</p>
             </div>
             <div class="checkbox-field">
               <label><input id="predict-shap" type="checkbox" /> Include SHAP</label>
@@ -130,7 +130,7 @@
             <div id="event-preview" class="event-preview">Upcoming events load automatically.</div>
             <details>
               <summary>Manual Event Odds</summary>
-              <p class="field-note">Odds are not included in the model. They are only used to calculate market-implied probability and expected value.</p>
+              <p class="field-note">These live event odds are not passed into the model. They are only used to calculate market-implied probability and expected value.</p>
               <textarea id="event-manual-odds" rows="5" placeholder="fighter name=-150&#10;other fighter=+200"></textarea>
             </details>
             <button id="run-event-predict" class="primary wide" disabled><i data-lucide="badge-dollar-sign"></i><span>Predict Event</span></button>

--- a/tests/e2e/test_data_tab_analytics_prompt.py
+++ b/tests/e2e/test_data_tab_analytics_prompt.py
@@ -77,7 +77,7 @@ def test_data_tab_analytics_prompt_copy_smoke(monkeypatch, tmp_path):
     prompt_response = client.get("/api/data/analytics/system-prompt")
     assert prompt_response.status_code == 200
     prompt_payload = prompt_response.json()
-    assert prompt_payload["version"] == "2026-06-01"
+    assert prompt_payload["version"] == "2026-06-05"
     assert "MMA AI Data Tab analytics agent" in prompt_payload["system_prompt"]
     assert "_adjperf" in prompt_payload["system_prompt"]
     assert "features.odds" in prompt_payload["system_prompt"]

--- a/tests/test_web/test_api.py
+++ b/tests/test_web/test_api.py
@@ -139,10 +139,12 @@ def test_analytics_system_prompt_endpoint_returns_copyable_prompt():
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["version"] == "2026-06-01"
+    assert payload["version"] == "2026-06-05"
     assert "MMA AI Data Tab analytics agent" in payload["system_prompt"]
     assert "_adjperf" in payload["system_prompt"]
     assert "features.odds" in payload["system_prompt"]
+    assert "decimal odds" in payload["system_prompt"]
+    assert "Treat it as post-fight" in payload["system_prompt"]
 
 
 def test_data_refresh_endpoint_starts_background_job(monkeypatch):

--- a/tests/test_web/test_release_docs.py
+++ b/tests/test_web/test_release_docs.py
@@ -121,7 +121,7 @@ def test_public_release_docs_cover_runtime_and_dashboard_surface():
     assert "Train tab" not in release_notes
     assert "Predict tab" in release_notes
     assert "mma-evaluate" in release_notes
-    assert "Odds are enabled by default but are not model\n  inputs" in release_notes
+    assert "Prediction-time live/manual odds are enabled by\n  default" in release_notes
     assert "does not expose per-fighter odds controls" in release_notes
     assert "Flaresolverr proxy toggle" in release_notes
     assert "wait for `/api/readiness`" in release_notes

--- a/tests/test_web/test_static_ui.py
+++ b/tests/test_web/test_static_ui.py
@@ -150,7 +150,7 @@ def test_predict_model_dropdown_filters_with_selected_target():
     assert '<label class="span-two">Model <select id="predict-model"></select></label>' in html
     assert '<input id="predict-odds" type="checkbox" /> Odds' in html
     assert '<label><input id="predict-shap" type="checkbox" /> Include SHAP</label>' in html
-    assert "Odds are not a feature in the model; they solely exist to calculate the Expected Value of each prediction." in html
+    assert "These live prediction odds are not passed into the model; they solely exist to calculate the Expected Value of each prediction." in html
     assert "Creates per-feature reasoning for why a fighter was picked" in html
     assert html.index("Advanced Prediction Knobs") < html.index('id="predict-model-type"')
     assert 'id="predict-flaresolverr"' in html
@@ -224,7 +224,7 @@ def test_predict_tab_auto_loads_upcoming_event_dropdown_with_odds_context():
     assert 'id="predict-event"' in html
     assert 'id="event-preview"' in html
     assert "Loading upcoming events..." in html
-    assert "Odds are not included in the model" in html
+    assert "These live event odds are not passed into the model" in html
     assert "async function loadUpcomingEvents()" in app_js
     assert "function renderUpcomingEventsError(message)" in app_js
     assert "async function loadUpcomingEventsWithStatus()" in app_js


### PR DESCRIPTION
## Summary

- Add `docs/ANALYTICS_SCHEMA.md` as a plain-English analytics schema reference covering feature families, suffixes, `_adjperf`, leakage rules, odds DB structure, and query patterns.
- Align README, AGENTS, CLAUDE, release notes, dashboard prompt, and Predict tab copy with corrected odds and feature semantics.
- Bump the analytics prompt version and update tests that pin prompt/static copy.

## Validation

- `uv run pytest tests/test_web/test_api.py::test_analytics_system_prompt_endpoint_returns_copyable_prompt -q`
- `uv run pytest tests/test_web/test_release_docs.py::test_public_release_docs_cover_runtime_and_dashboard_surface -q`
- `uv run pytest tests/test_web/test_static_ui.py -q`
- `uv run pytest tests/e2e/test_data_tab_analytics_prompt.py::test_data_tab_analytics_prompt_copy_smoke -q`