### PR TITLE
[codex] Harden public release secret guardrails

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,16 @@
 .git
 .cursor
 .env
+.env.*
 .env.local
+.envrc
+.npmrc
+.pypirc
+.netrc
+*.pem
+*.key
+*.p12
+*.pfx
 .webapp*.log
 .pytest_cache
 tests

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,24 @@ logs/
 
 # Environment variables
 .env
+.env.*
 .env.local
+!.env.example
+!tests/.env.example
+.envrc
+.npmrc
+.pypirc
+.netrc
+
+# Secret/key material
+*.pem
+*.key
+*.p12
+*.pfx
+*.kdbx
+*.ovpn
+credentials.json
+secrets.json
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/scripts/release_audit.py
+++ b/scripts/release_audit.py
@@ -50,16 +50,65 @@ REQUIRED_TRACKED_FILES = {
     "uv.lock",
     *SEED_DATA_PATHS,
 }
-FORBIDDEN_PREFIXES = (".cursor/", "AutoGluonModels/", "AutogluonModels/", "artifacts/", "pics/", "data/predictions/")
-FORBIDDEN_EXACT_FILES = {".env", ".env.local"}
-FORBIDDEN_SUFFIXES = (".png", ".jpg", ".jpeg", ".gif", ".ipynb", ".log")
+FORBIDDEN_PREFIXES = (
+    ".cursor/",
+    ".venv/",
+    "venv/",
+    "env/",
+    "ENV/",
+    "AutoGluonModels/",
+    "AutogluonModels/",
+    "artifacts/",
+    "build/",
+    "dist/",
+    "mma_ai.egg-info/",
+    "pics/",
+    "data/predictions/",
+)
+FORBIDDEN_EXACT_FILES = {".env", ".env.local", ".envrc", ".netrc", ".npmrc", ".pypirc"}
+FORBIDDEN_SUFFIXES = (
+    ".7z",
+    ".bak",
+    ".backup",
+    ".db",
+    ".dump",
+    ".gif",
+    ".gz",
+    ".ipynb",
+    ".joblib",
+    ".jpg",
+    ".jpeg",
+    ".kdbx",
+    ".key",
+    ".log",
+    ".ovpn",
+    ".p12",
+    ".pem",
+    ".pfx",
+    ".pkl",
+    ".png",
+    ".rar",
+    ".sqlite",
+    ".sqlite3",
+    ".tar",
+    ".zip",
+)
 ASCII_RUNTIME_LOG_FILES = {"predict.py"}
 MIN_SEED_ROWS = 1000
 MIN_SEED_COLUMNS = 6
 REQUIRED_DOCKERIGNORE_LINES = {
     ".env",
+    ".env.*",
     ".env.local",
+    ".envrc",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    "*.key",
     "*.log",
+    "*.p12",
+    "*.pem",
+    "*.pfx",
     "*.csv",
     "*.html",
     "logs",
@@ -139,10 +188,14 @@ def find_forbidden_artifacts(paths: Iterable[str]) -> list[AuditIssue]:
     issues: list[AuditIssue] = []
     for path in paths:
         normalized = path.replace("\\", "/")
+        filename = Path(normalized).name
+        lower_filename = filename.lower()
         if normalized in SEED_DATA_PATHS:
             continue
         if (
             normalized in FORBIDDEN_EXACT_FILES
+            or filename in FORBIDDEN_EXACT_FILES
+            or (lower_filename.startswith(".env.") and lower_filename != ".env.example")
             or normalized in GENERATED_DATA_FILES
             or normalized.startswith(FORBIDDEN_PREFIXES)
             or normalized.lower().endswith(FORBIDDEN_SUFFIXES)

--- a/tests/test_release_audit.py
+++ b/tests/test_release_audit.py
@@ -50,10 +50,16 @@ def test_release_audit_allows_only_seed_raw_csvs_from_data():
     issues = find_forbidden_artifacts(
         [
             ".env",
+            ".env.production",
+            ".envrc",
+            ".npmrc",
             ".webapp.out.log",
             "data/raw/ufcstats/competitions.csv",
             "data/raw/ufcstats/individuals.csv",
             "data/prediction_data.csv",
+            "secrets/service-account.pem",
+            "models/model.pkl",
+            ".venv/pyvenv.cfg",
             "AutoGluonModels/ag-test/predictor.pkl",
             "AutogluonModels/ag-test/predictor.pkl",
             ".cursor/rules/project-description.mdc",
@@ -63,8 +69,14 @@ def test_release_audit_allows_only_seed_raw_csvs_from_data():
 
     assert [issue.path for issue in issues] == [
         ".env",
+        ".env.production",
+        ".envrc",
+        ".npmrc",
         ".webapp.out.log",
         "data/prediction_data.csv",
+        "secrets/service-account.pem",
+        "models/model.pkl",
+        ".venv/pyvenv.cfg",
         "AutoGluonModels/ag-test/predictor.pkl",
         "AutogluonModels/ag-test/predictor.pkl",
         ".cursor/rules/project-description.mdc",


### PR DESCRIPTION
## Summary

- Ignore more local secret/config files in Git and Docker build contexts.
- Extend the release audit to reject tracked env variants, key material, archives, database dumps, model artifacts, virtualenvs, and build outputs.
- Add release audit coverage for those guarded artifact types.

## Validation

- `uv run pytest tests/test_release_audit.py -q`
- `uv run pytest tests/test_web/test_release_docs.py -q`
- `uv run mma-release-audit`