### PR TITLE
Refresh UFCStats data and handle challenge

### DIFF
--- a/data/raw/ufcstats/individuals.csv
+++ b/data/raw/ufcstats/individuals.csv
@@ -4454,3 +4454,135 @@ Julien Leblanc,--,http://ufcstats.com/fighter-details/cd0dfd9846bd03b9,"Jan 21, 
 Regina Malpica,Kill Bill,http://ufcstats.com/fighter-details/bc7f4b2d4c2724a2,"Oct 19, 2004",125 lbs.,--,--,--
 Gokhan Saricam,--,http://ufcstats.com/fighter-details/1a97a3ef4c758fae,"Feb 26, 1991",265 lbs.,--,--,--
 Gianni Vazquez,Kriptonita,http://ufcstats.com/fighter-details/51ec9dc3b4964f19,"Jul 17, 1994",135 lbs.,"71""","5' 7""",Orthodox
+Ryoga Arimoto,--,http://ufcstats.com/fighter-details/e0e1801e8721af17,"Dec 07, 1998",125 lbs.,"63""","5' 3""",Orthodox
+Lucas Brennan,Skywalker,http://ufcstats.com/fighter-details/33a8708747b7f943,"Jun 03, 2000",155 lbs.,"72""","5' 10""",Southpaw
+Otgonbaatar Boldbaatar,Conqueror,http://ufcstats.com/fighter-details/3f773caad71c4131,"Dec 25, 2002",125 lbs.,"67""","5' 5""",Orthodox
+Stan Dorsainvil,The Drill,http://ufcstats.com/fighter-details/5be51426ff3c1929,"May 12, 2000",155 lbs.,--,--,--
+Salhahuddin Everett,--,http://ufcstats.com/fighter-details/4c718f671bf0b525,--,185 lbs.,--,--,--
+Machi Fukuda,Kakutou Komachi,http://ufcstats.com/fighter-details/42189c98d434a413,"Jun 03, 2003",115 lbs.,"61""","5' 0""",Southpaw
+Hugo Guillon,--,http://ufcstats.com/fighter-details/aabf33d691f64d61,"Apr 12, 1997",185 lbs.,--,--,--
+Abdul Hussein,King,http://ufcstats.com/fighter-details/0e6bc8d1d6c0ad90,"Aug 02, 1997",135 lbs.,"67""","5' 7""",Orthodox
+Kento Imai,--,http://ufcstats.com/fighter-details/3abe2b6b2d9b7efc,"Aug 10, 1999",125 lbs.,--,--,--
+Reginaldo Junior,The Beast,http://ufcstats.com/fighter-details/9e6cd25e0bd05e3d,"Feb 10, 1999",170 lbs.,--,--,--
+Ryan Kuse,Third Street Savage,http://ufcstats.com/fighter-details/d958ed9e5a08c849,"Jun 24, 1994",145 lbs.,--,--,--
+Colton Loud,--,http://ufcstats.com/fighter-details/1c01e9a0c44e3128,"Dec 07, 2000",125 lbs.,--,--,--
+Norbert Novenyi,Magic,http://ufcstats.com/fighter-details/770108c77e4bcfd8,"Oct 06, 1999",185 lbs.,--,--,--
+Kasib Murdoch,Murder,http://ufcstats.com/fighter-details/3a51f8d30900b580,"May 15, 2001",135 lbs.,"65""","5' 4""",Orthodox
+Paris Moran,--,http://ufcstats.com/fighter-details/abe2e048a04d22cf,"Feb 04, 1996",125 lbs.,--,--,--
+Jaden Ortega,--,http://ufcstats.com/fighter-details/fc425affea8ca8cb,"Sep 18, 2002",170 lbs.,--,--,--
+Emilio Quissua,Rixa,http://ufcstats.com/fighter-details/2b13dba37724eb87,"Apr 21, 1997",205 lbs.,--,--,--
+Summer Onley,Ice Cold,http://ufcstats.com/fighter-details/c9ef8dcc299f4f75,--,135 lbs.,--,--,--
+Kaito Oda,--,http://ufcstats.com/fighter-details/629bac37f70891fb,"Feb 13, 1998",125 lbs.,"63""","5' 5""",Orthodox
+Roman Gabriel Puga,--,http://ufcstats.com/fighter-details/44f95ae20a6238e5,"Sep 17, 1996",145 lbs.,"71""","5' 7""",Orthodox
+Damian Piwowarczyk,Damsyn,http://ufcstats.com/fighter-details/30b7ef4026bd7c15,"Sep 14, 1997",205 lbs.,--,--,--
+Carlos Petruzella,Tito,http://ufcstats.com/fighter-details/2e1f3640443272ad,"Mar 29, 1997",185 lbs.,--,--,--
+Mayton Perea,Lion,http://ufcstats.com/fighter-details/19c46512d8dd6202,"Aug 18, 2000",170 lbs.,--,--,--
+Logan Paxton,Warverine,http://ufcstats.com/fighter-details/b4ce04f082391b54,"Aug 04, 1995",155 lbs.,"70""","5' 8""",Orthodox
+Stefano Paterno,--,http://ufcstats.com/fighter-details/12954cff4025a427,"Aug 18, 1995",170 lbs.,--,--,--
+Salahdine Parnasse,--,http://ufcstats.com/fighter-details/b3cb9dfccff3be76,"Dec 04, 1997",155 lbs.,--,--,--
+BoHyun Park,The Rush,http://ufcstats.com/fighter-details/504d3a11e4408253,"May 14, 1999",115 lbs.,"61""","5' 2""",Orthodox
+Tom Pagliarulo,The Phenom,http://ufcstats.com/fighter-details/0e75cd3ba8274cea,"Jun 19, 1997",145 lbs.,"74""","6' 0""",Switch
+Ryuho Miyaguchi,--,http://ufcstats.com/fighter-details/f1a9c0998c683782,"Jan 27, 1998",135 lbs.,"68""","5' 10""",Orthodox
+Richie Miranda,El Machete,http://ufcstats.com/fighter-details/abde3388a589103c,"Aug 12, 1994",155 lbs.,"75""","5' 8""",Southpaw
+Alexis Miranda,Mantis,http://ufcstats.com/fighter-details/d458266c796643e2,"Jan 03, 1999",170 lbs.,--,--,--
+Bella Mir,Lady,http://ufcstats.com/fighter-details/9ab21ab88230ce48,"Jan 01, 2003",135 lbs.,--,--,--
+Artur Minev,Headhunter,http://ufcstats.com/fighter-details/20d37922ba85e6fc,"Sep 27, 2003",155 lbs.,"69""","5' 9""",Orthodox
+Yunosuke Minami,--,http://ufcstats.com/fighter-details/9f2c07bd65fde55c,"Sep 10, 2000",135 lbs.,"65""","5' 5""",Orthodox
+Nina Milosevic,Queen Beast,http://ufcstats.com/fighter-details/eabece0edc2d62ca,"Aug 08, 1996",135 lbs.,"67""","5' 5""",Orthodox
+Meng Bo,--,http://ufcstats.com/fighter-details/2d85fcb4468c30d7,"Mar 29, 1996",115 lbs.,"62""","5' 4""",Orthodox
+Anna Melisano,Bandana,http://ufcstats.com/fighter-details/40a7ec5d1ad6ffa8,"May 20, 1997",125 lbs.,"68""","5' 4""",Orthodox
+Liam McCracken,--,http://ufcstats.com/fighter-details/e431ed30fc027c77,"Sep 07, 2001",155 lbs.,--,--,--
+Ozzy Martin,Toro,http://ufcstats.com/fighter-details/d0359429b6adb404,"Sep 18, 2002",170 lbs.,--,--,--
+Yilizhati Maimaitijiang,--,http://ufcstats.com/fighter-details/df1e855932897f45,--,185 lbs.,--,--,--
+Borislav Nikolic,Zombee,http://ufcstats.com/fighter-details/5f926979c980b87e,"Jan 29, 1993",135 lbs.,"72""","5' 9""",Orthodox
+Cameron Nelson,--,http://ufcstats.com/fighter-details/34d4cae19105eb68,"Jul 28, 1998",170 lbs.,--,--,--
+Jefferson Nascimento,Toddynho,http://ufcstats.com/fighter-details/4b85abc5abbe657c,"Nov 19, 1998",170 lbs.,"70""","5' 8""",Orthodox
+Gabriel Lorenco,Black Mamba,http://ufcstats.com/fighter-details/e3fc6c1fab298561,"Sep 30, 1999",--,--,--,--
+Liu Ce,--,http://ufcstats.com/fighter-details/a9936818d709e2d7,"Sep 04, 1996",205 lbs.,--,--,--
+GwanWoo Lim,The Giant,http://ufcstats.com/fighter-details/a53657e43b00614e,"Jul 27, 2001",145 lbs.,"74""","6' 2""",Southpaw
+YiSak Lee,The Tank,http://ufcstats.com/fighter-details/e6666480a830f764,"Jan 01, 2000",185 lbs.,"72""","6' 0""",Orthodox
+Joseph Larcinese,Big Sexy,http://ufcstats.com/fighter-details/62a72adeb0227603,"Oct 01, 1998",125 lbs.,"64""","5' 3""",Orthodox
+Joe Kropschot,The Land Animal,http://ufcstats.com/fighter-details/8a81a0707350c4a8,"Jun 19, 1995",185 lbs.,"79""","6' 3""",Orthodox
+Martin Kozak,CEO,http://ufcstats.com/fighter-details/716538be58c6c5e1,"Jul 09, 2002",185 lbs.,--,--,--
+Ben Johnston,--,http://ufcstats.com/fighter-details/3261aa79bf6caa64,"Oct 11, 1990",185 lbs.,"76""","6' 4""",Orthodox
+Milos Janicic,The Cobra,http://ufcstats.com/fighter-details/dfcadfcbd3a3f097,"May 03, 1997",155 lbs.,"71""","5' 11""",Orthodox
+Matty Iann,Ironside,http://ufcstats.com/fighter-details/031c06c8210e357c,"Oct 26, 2000",135 lbs.,--,--,--
+Zevan Hunt,Cheese,http://ufcstats.com/fighter-details/da27d061bad0f341,"Dec 08, 1998",170 lbs.,--,--,--
+Ronald Humphrey,--,http://ufcstats.com/fighter-details/15e0d2df09025bda,"Sep 20, 2000",170 lbs.,--,--,--
+Dakota Hope,Huracan,http://ufcstats.com/fighter-details/6142edbd477d20c9,"Jan 29, 1997",155 lbs.,"68""","5' 6""",--
+Luis Hernandez,The Stache,http://ufcstats.com/fighter-details/5dad1e8a516e6477,"Aug 22, 1996",185 lbs.,--,--,--
+Farman Hasanov,The Lion,http://ufcstats.com/fighter-details/c88f8a9c1ea7165d,"Aug 01, 1995",170 lbs.,"74""","5' 11""",Orthodox
+Bilal Hasan,The IndoNinja,http://ufcstats.com/fighter-details/5182316da3c1d891,"Jul 16, 2001",125 lbs.,"70""","5' 7""",Switch
+RJ Harris,The Hammer,http://ufcstats.com/fighter-details/e03187ec8b5b6abc,"Oct 01, 1998",258 lbs.,"78""","6' 3""",Orthodox
+Noah Gugnon,Guns,http://ufcstats.com/fighter-details/6266abf6e4245c72,"Oct 18, 2000",155 lbs.,"71""","5' 11""",Orthodox
+Piero Guaylupo,El Lobo,http://ufcstats.com/fighter-details/b4e8867d60ef0e69,"Oct 29, 2004",155 lbs.,--,--,--
+Severino Apollo Gomes,Deus Da Guerra,http://ufcstats.com/fighter-details/b3db81defb03d7af,"Jul 10, 2000",145 lbs.,--,--,--
+Magomedrasul Gasanov,--,http://ufcstats.com/fighter-details/30ba4c2779e68a1e,"Oct 23, 1994",170 lbs.,--,--,--
+John Garza,Mowgli,http://ufcstats.com/fighter-details/a54b961a1f8be1d5,"Oct 30, 2002",135 lbs.,"68""","5' 7""",Orthodox
+Nicholas Galanti,--,http://ufcstats.com/fighter-details/8988705468d04ef7,"Jun 18, 1998",185 lbs.,--,--,--
+Anthony Figueroa,--,http://ufcstats.com/fighter-details/35e3a24591f4e2cd,--,155 lbs.,--,--,--
+Namo Fazil,The Grandson of Saladin,http://ufcstats.com/fighter-details/f36af23639501cdf,"Oct 29, 1996",170 lbs.,"71""","5' 11""",Orthodox
+Fabrizio Escarrega,El Cachorro,http://ufcstats.com/fighter-details/9ebd666f99ba686b,"Feb 18, 1998",155 lbs.,"74""","5' 9""",Orthodox
+Ezra Elliott,--,http://ufcstats.com/fighter-details/b852ad2b35354fcb,"May 18, 2000",145 lbs.,"72""","5' 9""",Orthodox
+Christian Edwards,Pain,http://ufcstats.com/fighter-details/f5d82eccdea4e2dd,"Nov 05, 1998",205 lbs.,"78""","6' 5""",Southpaw
+Adama Diop,Blinde,http://ufcstats.com/fighter-details/8730ab4b1057f925,--,--,--,--,--
+Rabindra Dhant,--,http://ufcstats.com/fighter-details/9f8bd85aaeec2f56,"Nov 30, 1998",135 lbs.,"69""","5' 7""",Switch
+Marcos Degli,Tailandes,http://ufcstats.com/fighter-details/0575068a0f83f963,"May 13, 2000",125 lbs.,--,--,--
+Alvi Dasuyev,Spartan,http://ufcstats.com/fighter-details/03c629aaa15a17ce,--,170 lbs.,--,--,--
+Adam Darby,The Plank,http://ufcstats.com/fighter-details/a4555c13e6257539,"Nov 13, 1998",170 lbs.,--,--,--
+Callum Connor,007,http://ufcstats.com/fighter-details/6ab620a6b7e80a72,--,155 lbs.,--,--,--
+Shane Collins,Hollywood,http://ufcstats.com/fighter-details/70fc8214822b5a85,"Mar 08, 2000",145 lbs.,"71""","5' 9""",Orthodox
+Charlie Cleveland,The Reaper,http://ufcstats.com/fighter-details/a221b4812b0e7364,"Dec 30, 1997",248 lbs.,--,--,--
+Sean Clancy Jr.,The One,http://ufcstats.com/fighter-details/c02862a5f6d3fbd0,"Nov 25, 2002",170 lbs.,--,--,--
+Levan Chokheli,--,http://ufcstats.com/fighter-details/a69a7120cf26669d,"Oct 02, 1996",170 lbs.,"72""","5' 11""",Orthodox
+Dagiisuren Chagnaadorj,--,http://ufcstats.com/fighter-details/70186298465de3f3,"Dec 31, 1999",145 lbs.,"71""","5' 8""",Orthodox
+Terrance Chatman,The Answer,http://ufcstats.com/fighter-details/23a81656507b56a3,--,265 lbs.,--,--,--
+Vlasto Cepo,El Chapo,http://ufcstats.com/fighter-details/025c1ee70b2cedf4,"Jan 25, 1995",185 lbs.,"73""","6' 0""",Orthodox
+Gigi Canuto,Diamond,http://ufcstats.com/fighter-details/651d209fa8c8cd83,"Nov 16, 2002",115 lbs.,"64""","5' 2""",Orthodox
+Alivia Bierley,--,http://ufcstats.com/fighter-details/f2da98858f61ca78,"Sep 20, 1996",135 lbs.,--,--,--
+Yudi Cahyadi,Prabu Gagak Lumayung,http://ufcstats.com/fighter-details/8c457cf7da551d4b,"Apr 01, 1992",145 lbs.,"68""","5' 6""",Orthodox
+Arlind Berisha,--,http://ufcstats.com/fighter-details/364e7a7a1ea5e200,"Nov 05, 2000",205 lbs.,--,--,--
+Theodor Berggren,Simba,http://ufcstats.com/fighter-details/feef5f8f5629e5e7,"Apr 09, 2000",170 lbs.,"75""","5' 11""",Switch
+Delphine Benouaich,--,http://ufcstats.com/fighter-details/3138df4d117ebc12,"Mar 21, 1995",115 lbs.,--,--,--
+Eros Baluyot,--,http://ufcstats.com/fighter-details/3497f4c29654862c,"Oct 23, 1992",125 lbs.,"65""","5' 4""",Orthodox
+Gary Balletto,Batman,http://ufcstats.com/fighter-details/623f2eed9e1495af,"Jan 20, 1995",170 lbs.,--,--,--
+Nell Ariano,--,http://ufcstats.com/fighter-details/0adbaf643b60b130,--,205 lbs.,--,--,--
+Alexis Apodaca,--,http://ufcstats.com/fighter-details/14a48a86b2b57f0e,--,135 lbs.,--,--,--
+Damien Anderson,Demon Hands,http://ufcstats.com/fighter-details/df619b9a86ce0a9a,"Jan 04, 1997",145 lbs.,"69""","5' 8""",Southpaw
+Abe Alsaghir,The Killer,http://ufcstats.com/fighter-details/27a9ce2c04071efe,"Jul 01, 2001",155 lbs.,"71""","5' 8""",Orthodox
+Kimbert Alintozon,The Hunter,http://ufcstats.com/fighter-details/a075a34d7527fadf,"Jan 21, 1999",135 lbs.,"65""","5' 3""",Orthodox
+Matt Adams,Bad,http://ufcstats.com/fighter-details/acff8cdcfc634cb5,"Sep 07, 1997",235 lbs.,"75""","5' 11""",Orthodox
+Tahir Abdullayev,Tank,http://ufcstats.com/fighter-details/e047d3b541afd4a7,"Feb 02, 1997",170 lbs.,"73""","5' 8""",Orthodox
+Akbar Abdullaev,Bakal,http://ufcstats.com/fighter-details/24cb8f04de1310cb,"Sep 20, 1997",155 lbs.,--,--,--
+Farida Abdueva,--,http://ufcstats.com/fighter-details/8f3837b4c06f3d1e,"May 15, 2004",115 lbs.,"66""","5' 3""",Orthodox
+Damian Rzepecki,The Butcher,http://ufcstats.com/fighter-details/99223fbb4a05326b,"Nov 23, 2001",155 lbs.,"71""","5' 10""",Orthodox
+Jessie Rosas,Tachidito,http://ufcstats.com/fighter-details/d1026588fa65693f,"Dec 04, 2002",135 lbs.,"68""","5' 7""",Southpaw
+Nilson Rojas,El Rayo,http://ufcstats.com/fighter-details/bf60dd3256801649,"Apr 21, 1999",125 lbs.,--,--,--
+Modestino Rodrigues,The Slenderman,http://ufcstats.com/fighter-details/48e43b65f7838878,"Oct 09, 2003",185 lbs.,--,--,--
+Douglas Rodrigues,Blade,http://ufcstats.com/fighter-details/19388069e19ec6b9,"Jan 13, 1999",185 lbs.,"74""","6' 0""",Orthodox
+Patrick Rivera,--,http://ufcstats.com/fighter-details/73ab2872b8633322,"Feb 24, 1992",170 lbs.,--,--,--
+Camila Reynoso,Buttercup,http://ufcstats.com/fighter-details/7631e2ba8e1ab9a5,"Aug 28, 2003",115 lbs.,--,--,--
+Regezhen,Chocolate Boy,http://ufcstats.com/fighter-details/be5fd2ae27d20842,"Feb 28, 2001",145 lbs.,"69""","5' 8""",Orthodox
+Oscar Ravello,The Punisher,http://ufcstats.com/fighter-details/56370b594d5fe0b3,"Sep 27, 1998",185 lbs.,--,--,--
+Takaya Suzuki,--,http://ufcstats.com/fighter-details/81d59c1e07478361,"Sep 08, 2004",125 lbs.,"68""","5' 7""",Southpaw
+Magomed Tuchalov,Tiger,http://ufcstats.com/fighter-details/bc5a51159ec2fdf2,"Dec 30, 1999",205 lbs.,"78""","6' 3""",Orthodox
+Alexander Trujillo,--,http://ufcstats.com/fighter-details/ccf25f81fcdaecb4,"Oct 01, 2000",125 lbs.,--,--,--
+Rodrigo Vera,El Gato Loco,http://ufcstats.com/fighter-details/2b266e623e20737a,"Oct 18, 1995",145 lbs.,"68""","5' 8""",Orthodox
+Abubakar Vagaev,--,http://ufcstats.com/fighter-details/f7adc1fd115f8fdd,"Apr 14, 1993",170 lbs.,"73""","5' 11""",Orthodox
+Xiong Jingnan,The Panda,http://ufcstats.com/fighter-details/2cdb479a0ef0ee1d,"Jan 12, 1988",115 lbs.,"63""","5' 4""",Switch
+Yuito Yanagawa,--,http://ufcstats.com/fighter-details/7c592bf20095fd17,"Oct 16, 2000",145 lbs.,"68""","5' 8""",Orthodox
+Hailai Wushamo,--,http://ufcstats.com/fighter-details/78f4cad9548b79e1,"Sep 03, 2000",115 lbs.,--,--,--
+Anthony Wint,Bow Down,http://ufcstats.com/fighter-details/b34976c022b24568,"Sep 14, 1995",234 lbs.,"78""","5' 11""",Orthodox
+Taner Trembley,Killemquick,http://ufcstats.com/fighter-details/00b8dd0fbe2fbfd9,"Dec 28, 1994",145 lbs.,"69""","5' 9""",Orthodox
+Tyshawn Williams,--,http://ufcstats.com/fighter-details/2e75399d5a934b0e,"Aug 24, 1996",145 lbs.,--,--,--
+Anelya Toktogonova,--,http://ufcstats.com/fighter-details/3a89481e3a9d47c0,"Aug 01, 2005",115 lbs.,"63""","5' 2""",Southpaw
+Ryo Tajima,--,http://ufcstats.com/fighter-details/34fbfc3f65b64645,"Aug 14, 1999",135 lbs.,"71""","5' 8""",Orthodox
+Gable Steveson,--,http://ufcstats.com/fighter-details/f7e856a73c96048e,"May 31, 2000",249 lbs.,"74""","5' 11""",Orthodox
+Marina Spasic,Maki Beki,http://ufcstats.com/fighter-details/5847c1a960bb23af,"Jul 11, 1994",115 lbs.,"64""","5' 4""",Orthodox
+Hunter Smith,Headshot,http://ufcstats.com/fighter-details/c3217a727e43b0cd,"Oct 27, 1998",155 lbs.,--,--,--
+Jamie Siraj,The Gremlin,http://ufcstats.com/fighter-details/e6679e38e7fab7a8,"Jun 28, 1994",135 lbs.,"66""","5' 7""",Orthodox
+Youmin Shin,--,http://ufcstats.com/fighter-details/b94ac19bad67a389,--,135 lbs.,--,--,--
+Ollie Schmid,The Hungarian Stallion,http://ufcstats.com/fighter-details/b701f095e6ccb149,"Dec 28, 2000",145 lbs.,"71""","6' 0""",Orthodox
+Silvestre Sanchez,Gorilla,http://ufcstats.com/fighter-details/acdefc52a4b6c576,"Nov 15, 2001",155 lbs.,--,--,--
+Muhammad Saidov,Kubik,http://ufcstats.com/fighter-details/b01a5e0dcd9f231d,"Jan 10, 1996",205 lbs.,"73""","6' 2""",Orthodox
+Zaurbek Sabanov,--,http://ufcstats.com/fighter-details/633f0800d178dd21,"Jun 14, 1998",255 lbs.,--,--,--

--- a/libs/scraping/ufcstats.py
+++ b/libs/scraping/ufcstats.py
@@ -44,7 +44,6 @@ COMPETITION_FIELDS = (
     + [f"{fighter}_rd{round_no}_{stat}" for fighter in ("p1", "p2") for stat in SIG_STR_SECTION_STATS for round_no in range(1, 6)]
 )
 
-
 def _normalize_text(value: str | None) -> str:
     return value.strip() if value else ""
 
@@ -52,6 +51,10 @@ def _normalize_text(value: str | None) -> str:
 def _nickname(value: str | None) -> str:
     cleaned = _normalize_text(value).replace('"', "")
     return cleaned if cleaned else "--"
+
+
+def _normalize_details(value: str | None) -> str:
+    return " ".join((value or "").split())
 
 
 def _read_existing_values(path: Path, column: str) -> set[str]:
@@ -179,7 +182,12 @@ if scrapy is not None:
         allowed_domains = ["ufcstats.com"]
         output_fields = FIGHTER_FIELDS
 
-        def __init__(self, existing_urls: Iterable[str] | None = None, output_path: str | Path | None = None, **kwargs):
+        def __init__(
+            self,
+            existing_urls: Iterable[str] | None = None,
+            output_path: str | Path | None = None,
+            **kwargs,
+        ):
             super().__init__(**kwargs)
             self.existing_urls = set(existing_urls or [])
             self.output_path = str(output_path)
@@ -217,7 +225,12 @@ if scrapy is not None:
         start_urls = ["http://ufcstats.com/statistics/events/completed?page=all"]
         output_fields = COMPETITION_FIELDS
 
-        def __init__(self, existing_event_urls: Iterable[str] | None = None, output_path: str | Path | None = None, **kwargs):
+        def __init__(
+            self,
+            existing_event_urls: Iterable[str] | None = None,
+            output_path: str | Path | None = None,
+            **kwargs,
+        ):
             super().__init__(**kwargs)
             self.existing_event_urls = set(existing_event_urls or [])
             self.output_path = str(output_path)
@@ -274,6 +287,7 @@ if scrapy is not None:
                     for text in node.css("::text").getall()
                     if text.strip()
                 )
+            details = _normalize_details(details)
 
             round_no = _normalize_text(response.xpath('//i[contains(text(), "Round:")]/following-sibling::text()').get())
             fight_data = {
@@ -371,6 +385,9 @@ def scrape_ufcstats(
             "REQUEST_FINGERPRINTER_IMPLEMENTATION": "2.7",
             "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
             "ITEM_PIPELINES": {"libs.scraping.ufcstats.CsvWriterPipeline": 300},
+            "DOWNLOADER_MIDDLEWARES": {
+                "libs.scraping.ufcstats_challenge.UfcstatsChallengeMiddleware": 580,
+            },
             "LOG_LEVEL": log_level,
         }
     )

--- a/libs/scraping/ufcstats_challenge.py
+++ b/libs/scraping/ufcstats_challenge.py
@@ -1,0 +1,234 @@
+"""Downloader middleware for UFCStats' JavaScript proof-of-work page."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Hashable
+from urllib.parse import urlsplit
+
+from scrapy import FormRequest, Request
+from scrapy.http import Response
+from scrapy.http.request import NO_CALLBACK
+from twisted.internet.defer import Deferred
+from twisted.python.failure import Failure
+
+
+class UfcstatsChallengeError(RuntimeError):
+    """Raised when UFCStats clearance cannot be obtained safely."""
+
+
+@dataclass
+class _Clearance:
+    owner: Request
+    waiters: list[tuple[Deferred, Request]] = field(default_factory=list)
+
+
+class UfcstatsChallengeMiddleware:
+    """Solve UFCStats' bounded SHA-256 challenge once per cookie jar."""
+
+    _CONTROL_META = "_ufcstats_challenge_control"
+    _RETRY_META = "_ufcstats_challenge_retries"
+    _NONCE_RE = re.compile(r"\bnonce\s*=\s*['\"]([0-9a-fA-F]{1,128})['\"]")
+    _DIFFICULTY_RE = re.compile(
+        r"\btarget\s*=\s*new\s+Array\(\s*(\d+)\s*\+\s*1\s*\)"
+        r"\.join\(\s*['\"]0['\"]\s*\)"
+    )
+
+    def __init__(
+        self,
+        max_difficulty: int = 5,
+        max_work: int = 2_000_000,
+        max_retries: int = 1,
+        max_waiters: int = 64,
+    ) -> None:
+        self.max_difficulty = max_difficulty
+        self.max_work = max_work
+        self.max_retries = max_retries
+        self.max_waiters = max_waiters
+        self._clearances: dict[tuple[str, Hashable], _Clearance] = {}
+        self._control_keys: dict[str, tuple[str, Hashable]] = {}
+        self._next_control_id = 0
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        settings = crawler.settings
+        return cls(
+            max_difficulty=settings.getint(
+                "UFCSTATS_CHALLENGE_MAX_DIFFICULTY", 5
+            ),
+            max_work=settings.getint("UFCSTATS_CHALLENGE_MAX_WORK", 2_000_000),
+            max_retries=settings.getint("UFCSTATS_CHALLENGE_MAX_RETRIES", 1),
+            max_waiters=settings.getint("UFCSTATS_CHALLENGE_MAX_WAITERS", 64),
+        )
+
+    def process_response(self, request, response, spider=None):
+        control_id = request.meta.get(self._CONTROL_META)
+        if control_id is not None:
+            return self._finish_clearance(control_id, response)
+
+        if not self._is_ufcstats(request.url):
+            return response
+
+        if self._has_interactive_captcha(response):
+            raise UfcstatsChallengeError(
+                f"UFCStats returned an interactive CAPTCHA for {request.url}"
+            )
+
+        if not self._is_known_challenge(response):
+            return response
+
+        retry_count = request.meta.get(self._RETRY_META, 0)
+        if retry_count >= self.max_retries:
+            raise UfcstatsChallengeError(
+                f"UFCStats proof-of-work challenge persisted after {retry_count} "
+                f"clearance attempt(s) for {request.url}"
+            )
+
+        key = self._clearance_key(request)
+        active = self._clearances.get(key)
+        if active is not None:
+            if len(active.waiters) >= self.max_waiters:
+                raise UfcstatsChallengeError(
+                    f"UFCStats clearance queue exceeded {self.max_waiters} requests"
+                )
+            waiter = Deferred()
+            waiter.addCallback(lambda _ignored: self._retry(request))
+            active.waiters.append((waiter, request))
+            return waiter
+
+        nonce, difficulty = self._parse_challenge(response)
+        answer = self._solve(nonce, difficulty)
+        self._next_control_id += 1
+        control_id = str(self._next_control_id)
+        self._clearances[key] = _Clearance(owner=request)
+        self._control_keys[control_id] = key
+
+        meta = request.meta.copy()
+        meta[self._CONTROL_META] = control_id
+        return FormRequest(
+            url=f"{urlsplit(request.url).scheme}://{urlsplit(request.url).netloc}/__c",
+            method="POST",
+            formdata={"nonce": nonce, "n": str(answer)},
+            callback=NO_CALLBACK,
+            dont_filter=True,
+            priority=request.priority + 1000,
+            meta=meta,
+        )
+
+    def process_exception(self, request, exception, spider=None):
+        control_id = request.meta.get(self._CONTROL_META)
+        if control_id is None:
+            return None
+        error = UfcstatsChallengeError(
+            f"UFCStats clearance request failed: {exception}"
+        )
+        self._abort_clearance(control_id, error)
+        raise error from exception
+
+    @staticmethod
+    def _is_ufcstats(url: str) -> bool:
+        return (urlsplit(url).hostname or "").lower() in {
+            "ufcstats.com",
+            "www.ufcstats.com",
+        }
+
+    @staticmethod
+    def _is_known_challenge(response: Response) -> bool:
+        if response.status != 200:
+            return False
+        body = response.body.lower()
+        return b"<title>loading" in body and b"checking your browser" in body
+
+    @staticmethod
+    def _has_interactive_captcha(response: Response) -> bool:
+        body = response.body.lower()
+        return any(
+            marker in body
+            for marker in (b"g-recaptcha", b"h-captcha", b"hcaptcha", b"cf-turnstile")
+        )
+
+    def _parse_challenge(self, response: Response) -> tuple[str, int]:
+        try:
+            script = response.text
+        except AttributeError as exc:
+            raise UfcstatsChallengeError(
+                "UFCStats challenge was not an HTML text response"
+            ) from exc
+
+        if 'xhr.open(\'POST\',"/__c"' not in script and 'xhr.open("POST","/__c"' not in script:
+            raise UfcstatsChallengeError(
+                "UFCStats challenge endpoint format changed"
+            )
+        nonce_match = self._NONCE_RE.search(script)
+        difficulty_match = self._DIFFICULTY_RE.search(script)
+        if nonce_match is None or difficulty_match is None:
+            raise UfcstatsChallengeError("UFCStats challenge format changed")
+
+        difficulty = int(difficulty_match.group(1))
+        if difficulty < 1 or difficulty > self.max_difficulty:
+            raise UfcstatsChallengeError(
+                f"UFCStats published unsupported proof difficulty {difficulty}; "
+                f"maximum is {self.max_difficulty}"
+            )
+        return nonce_match.group(1), difficulty
+
+    def _solve(self, nonce: str, difficulty: int) -> int:
+        target = "0" * difficulty
+        for answer in range(self.max_work):
+            digest = hashlib.sha256(f"{nonce}:{answer}".encode()).hexdigest()
+            if digest.startswith(target):
+                return answer
+        raise UfcstatsChallengeError(
+            f"UFCStats proof exceeded the {self.max_work}-hash work limit"
+        )
+
+    @staticmethod
+    def _clearance_key(request: Request) -> tuple[str, Hashable]:
+        host = (urlsplit(request.url).hostname or "").lower()
+        cookie_jar = request.meta.get("cookiejar")
+        try:
+            hash(cookie_jar)
+        except TypeError as exc:
+            raise UfcstatsChallengeError("Scrapy cookiejar key must be hashable") from exc
+        return host, cookie_jar
+
+    def _finish_clearance(self, control_id: str, response: Response) -> Request:
+        key = self._control_keys.pop(control_id, None)
+        clearance = self._clearances.pop(key, None) if key is not None else None
+        if clearance is None:
+            raise UfcstatsChallengeError("Unknown UFCStats clearance response")
+
+        set_cookie = b"\n".join(response.headers.getlist("Set-Cookie"))
+        if response.status != 204 or b"_fmc=" not in set_cookie:
+            error = UfcstatsChallengeError(
+                "UFCStats clearance was rejected or did not set the _fmc cookie "
+                f"(HTTP {response.status})"
+            )
+            self._fail_waiters(clearance, error)
+            raise error
+
+        for waiter, _request in clearance.waiters:
+            if not waiter.called:
+                waiter.callback(None)
+        return self._retry(clearance.owner)
+
+    def _abort_clearance(self, control_id: str, error: Exception) -> None:
+        key = self._control_keys.pop(control_id, None)
+        clearance = self._clearances.pop(key, None) if key is not None else None
+        if clearance is not None:
+            self._fail_waiters(clearance, error)
+
+    @staticmethod
+    def _fail_waiters(clearance: _Clearance, error: Exception) -> None:
+        for waiter, _request in clearance.waiters:
+            if not waiter.called:
+                waiter.errback(Failure(error))
+
+    def _retry(self, request: Request) -> Request:
+        retry_count = request.meta.get(self._RETRY_META, 0) + 1
+        return request.replace(
+            dont_filter=True,
+            meta={**request.meta, self._RETRY_META: retry_count},
+        )

--- a/tests/test_scraping/test_ufcstats_challenge_middleware.py
+++ b/tests/test_scraping/test_ufcstats_challenge_middleware.py
@@ -1,0 +1,165 @@
+import hashlib
+import unittest
+from urllib.parse import parse_qs
+
+from scrapy import Request
+from scrapy.downloadermiddlewares.cookies import CookiesMiddleware
+from scrapy.http import HtmlResponse
+
+from libs.scraping.ufcstats_challenge import (
+    UfcstatsChallengeError,
+    UfcstatsChallengeMiddleware,
+)
+
+
+CHALLENGE = b"""<!doctype html><html><head><title>Loading\xe2\x80\xa6</title></head>
+<body><p>Checking your browser\xe2\x80\xa6</p><script>
+function sha256(msg) { return msg; }
+var nonce="0ff11e0123456789", target=new Array(2+1).join('0');
+var n=0;
+while(sha256(nonce+':'+n).slice(0,target.length)!==target){n++;}
+var xhr=new XMLHttpRequest();
+xhr.open('POST',"/__c",true);
+xhr.send('nonce='+encodeURIComponent(nonce)+'&n='+n);
+</script></body></html>"""
+
+
+def response_for(request, body=CHALLENGE, status=200, headers=None):
+    return HtmlResponse(
+        request.url,
+        request=request,
+        body=body,
+        status=status,
+        headers=headers,
+        encoding="utf-8",
+    )
+
+
+class UfcstatsChallengeMiddlewareTests(unittest.TestCase):
+    def setUp(self):
+        self.middleware = UfcstatsChallengeMiddleware(max_work=100_000)
+        self.cookies = CookiesMiddleware()
+
+    def test_serializes_clearance_and_retries_with_cookie(self):
+        callback = lambda response: response
+        first = Request(
+            "http://ufcstats.com/statistics/events/completed?page=all",
+            callback=callback,
+        )
+        second = Request(
+            "http://ufcstats.com/statistics/fighters?char=a&page=all",
+            callback=callback,
+        )
+
+        control = self.middleware.process_response(
+            first, response_for(first), spider=None
+        )
+        waiting = self.middleware.process_response(
+            second, response_for(second), spider=None
+        )
+
+        self.assertEqual(control.url, "http://ufcstats.com/__c")
+        self.assertEqual(control.method, "POST")
+        form = parse_qs(control.body.decode())
+        self.assertEqual(form["nonce"], ["0ff11e0123456789"])
+        answer = form["n"][0]
+        self.assertTrue(
+            hashlib.sha256(f"0ff11e0123456789:{answer}".encode())
+            .hexdigest()
+            .startswith("00")
+        )
+        self.assertFalse(waiting.called)
+
+        cleared = response_for(
+            control,
+            body=b"",
+            status=204,
+            headers={"Set-Cookie": b"_fmc=offline-clearance; Path=/; HttpOnly"},
+        )
+        self.cookies.process_response(control, cleared)
+        first_retry = self.middleware.process_response(control, cleared, spider=None)
+        second_retry = waiting.result
+
+        self.assertTrue(waiting.called)
+        self.assertIs(first_retry.callback, callback)
+        self.assertIs(second_retry.callback, callback)
+        self.assertTrue(first_retry.dont_filter)
+        self.assertTrue(second_retry.dont_filter)
+
+        self.cookies.process_request(first_retry)
+        self.cookies.process_request(second_retry)
+        self.assertIn(b"_fmc=offline-clearance", first_retry.headers[b"Cookie"])
+        self.assertIn(b"_fmc=offline-clearance", second_retry.headers[b"Cookie"])
+
+    def test_persistent_challenge_fails_explicitly(self):
+        request = Request(
+            "http://ufcstats.com/statistics/events/completed?page=all",
+            meta={"_ufcstats_challenge_retries": 1},
+        )
+        with self.assertRaisesRegex(UfcstatsChallengeError, "persisted"):
+            self.middleware.process_response(request, response_for(request), spider=None)
+
+    def test_rejects_difficulty_above_configured_maximum(self):
+        middleware = UfcstatsChallengeMiddleware(max_difficulty=5)
+        request = Request("http://ufcstats.com/statistics/events/completed?page=all")
+        excessive = CHALLENGE.replace(b"new Array(2+1)", b"new Array(6+1)")
+
+        with self.assertRaisesRegex(
+            UfcstatsChallengeError, "unsupported proof difficulty 6"
+        ):
+            middleware.process_response(
+                request, response_for(request, excessive), spider=None
+            )
+
+    def test_fails_when_proof_work_limit_is_exhausted(self):
+        middleware = UfcstatsChallengeMiddleware(max_work=1)
+        request = Request("http://ufcstats.com/statistics/events/completed?page=all")
+        first_digest = hashlib.sha256(b"0ff11e0123456789:0").hexdigest()
+        self.assertFalse(first_digest.startswith("00"))
+
+        with self.assertRaisesRegex(UfcstatsChallengeError, "1-hash work limit"):
+            middleware.process_response(request, response_for(request), spider=None)
+
+    def test_rejects_requests_beyond_waiter_queue_bound(self):
+        middleware = UfcstatsChallengeMiddleware(
+            max_work=100_000,
+            max_waiters=1,
+        )
+        requests = [
+            Request(f"http://ufcstats.com/statistics/fighters?char={char}&page=all")
+            for char in "abc"
+        ]
+
+        control = middleware.process_response(
+            requests[0], response_for(requests[0]), spider=None
+        )
+        waiting = middleware.process_response(
+            requests[1], response_for(requests[1]), spider=None
+        )
+        with self.assertRaisesRegex(UfcstatsChallengeError, "exceeded 1 requests"):
+            middleware.process_response(
+                requests[2], response_for(requests[2]), spider=None
+            )
+
+        self.assertEqual(control.url, "http://ufcstats.com/__c")
+        self.assertFalse(waiting.called)
+
+    def test_changed_format_fails_instead_of_guessing(self):
+        request = Request("http://ufcstats.com/statistics/fighters?char=a&page=all")
+        changed = CHALLENGE.replace(b"new Array(2+1)", b"difficulty(2)")
+        with self.assertRaisesRegex(UfcstatsChallengeError, "format changed"):
+            self.middleware.process_response(
+                request, response_for(request, changed), spider=None
+            )
+
+    def test_interactive_captcha_fails_explicitly(self):
+        request = Request("http://ufcstats.com/statistics/fighters?char=a&page=all")
+        captcha = b"<html><div class='g-recaptcha'></div></html>"
+        with self.assertRaisesRegex(UfcstatsChallengeError, "interactive CAPTCHA"):
+            self.middleware.process_response(
+                request, response_for(request, captcha), spider=None
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scraping/test_ufcstats_merge.py
+++ b/tests/test_scraping/test_ufcstats_merge.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from libs.scraping.ufcstats import COMPETITION_FIELDS, FIGHTER_FIELDS, _merge_csv
+from libs.scraping.ufcstats import COMPETITION_FIELDS, FIGHTER_FIELDS, _merge_csv, _normalize_details
 
 
 def write_fighters(path: Path, rows: list[dict[str, str]]) -> None:
@@ -206,3 +206,7 @@ def test_force_full_merge_replaces_existing_rows(tmp_path):
     merged = pd.read_csv(existing)
     assert total == 1
     assert merged["url"].tolist() == ["replacement"]
+
+
+def test_fight_details_collapse_embedded_whitespace():
+    assert _normalize_details("to    \n  corner   stoppage") == "to corner stoppage"


### PR DESCRIPTION
## What

- add the UFCStats challenge-response downloader middleware from the working `tools/mma-ai-db` scraper implementation
- register the middleware in the Scrapy crawler and normalize fight-detail whitespace
- refresh fight and fighter CSV data
- add middleware and merge regression coverage

## Why

UFCStats now serves a JavaScript challenge that blocked the existing scraper. The middleware computes the required response and retries queued requests after clearance.

## Impact

- fights: 8,794 rows, including 262 newly discovered stable fight keys
- fighters: 4,587 rows, including 132 newly discovered fighter keys
- existing CSV merge and deduplication behavior remains covered

## Root cause

The crawler did not handle UFCStats' challenge page, so requests could not reach event and fighter content.

## Checks

- `git diff --cached --check`
- `uv run pytest tests/test_scraping -q` — 17 passed
- live scraper completed successfully and reported 4,587 fighters / 8,794 fights